### PR TITLE
chore: cleanup review

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,33 +1,37 @@
 {
   "extends": "@sapphire",
   "rules": {
-    "no-tabs": "error",
     "@typescript-eslint/no-namespace": "off",
     "@typescript-eslint/class-literal-property-style": "off",
+    "no-lone-blocks": "error",
+    "no-tabs": "error",
     "padding-line-between-statements": [
       "error",
-      { "blankLine": "always", "prev": "*", "next": "return" },
-
-      { "blankLine": "always", "prev": ["const", "let", "var"], "next": "*" },
-      { "blankLine": "any", "prev": ["const", "let", "var"], "next": ["const", "let", "var"] },
-
-      { "blankLine": "always", "prev": "directive", "next": "*" },
-      { "blankLine": "any", "prev": "directive", "next": "directive" },
-
-      { "blankLine": "always", "prev": ["case", "default"], "next": "*" },
-
-      { "blankLine": "always", "prev": "block", "next": "*" },
-
-      { "blankLine": "always", "prev": "block-like", "next": "*" },
-
-      { "blankLine": "always", "prev": "for", "next": "*" },
-      { "blankLine": "any", "prev": "for", "next": "for" },
-
-      { "blankLine": "always", "prev": "if", "next": "*" },
-      { "blankLine": "any", "prev": "if", "next": "if" },
-
-      { "blankLine": "always", "prev": "expression", "next": "*" },
-      { "blankLine": "any", "prev": "expression", "next": "expression" }
+      { "blankLine": "never", "prev": ["const", "let", "var"], "next": ["const", "let", "var"] },
+      { "blankLine": "never", "prev": "case", "next": "case" },
+      { "blankLine": "never", "prev": "expression", "next": "expression" },
+      { "blankLine": "never", "prev": "for", "next": "for" },
+      { "blankLine": "never", "prev": "if", "next": "if" },
+      {
+        "blankLine": "always",
+        "prev": [
+          "block-like",
+          "break",
+          "case",
+          "class",
+          "continue",
+          "default",
+          "multiline-const",
+          "multiline-expression",
+          "multiline-let",
+          "multiline-var",
+          "return",
+          "switch",
+          "try"
+        ],
+        "next": "*"
+      },
+      { "blankLine": "always", "prev": "*", "next": ["case", "default"] }
     ]
   }
 }

--- a/src/lib/errors/JoshError.ts
+++ b/src/lib/errors/JoshError.ts
@@ -13,7 +13,6 @@ export class JoshError extends Error {
     const { name, message, identifier } = options;
 
     super(message);
-
     this.name = name ?? 'JoshError';
     this.identifier = identifier;
   }

--- a/src/lib/errors/JoshProviderError.ts
+++ b/src/lib/errors/JoshProviderError.ts
@@ -16,7 +16,6 @@ export class JoshProviderError extends JoshError {
     const { name, method } = options;
 
     super({ ...options, name: name ?? 'JoshProviderError' });
-
     this.method = method ?? null;
   }
 }

--- a/src/lib/functions/index.ts
+++ b/src/lib/functions/index.ts
@@ -1,2 +1,3 @@
 export * from './convertLegacyExportJSON';
+export * from './resolveCommonIdentifier';
 export * from './validators';

--- a/src/lib/functions/resolveCommonIdentifier.ts
+++ b/src/lib/functions/resolveCommonIdentifier.ts
@@ -1,0 +1,43 @@
+import { CommonIdentifiers } from '../types';
+
+export function resolveCommonIdentifier(identifier: string, metadata: Record<string, unknown>): string | null {
+  switch (identifier) {
+    case CommonIdentifiers.InvalidCount:
+      return 'The "count" of items must be less than or equal to the amount of items in the provider.';
+
+    case CommonIdentifiers.InvalidDataType: {
+      const { key, path = [], type } = metadata;
+
+      if (typeof key === 'string') return null;
+      if (!Array.isArray(path)) return null;
+      if (typeof type !== 'string') return null;
+
+      return path.length === 0
+        ? `The data at "${key}" is invalid. Expected type: ${type.toUpperCase()}`
+        : `The data at "${key}.${path}" is invalid. Expected type: ${type.toUpperCase()}`;
+    }
+
+    case CommonIdentifiers.InvalidValueType: {
+      const { type } = metadata;
+
+      if (typeof type !== 'string') return null;
+
+      return `The "value" parameter is invalid. Expected type: ${type.toUpperCase()}`;
+    }
+
+    case CommonIdentifiers.MissingData: {
+      const { key, path = [] } = metadata;
+
+      if (typeof key === 'string') return null;
+      if (!Array.isArray(path)) return null;
+
+      return path.length === 0 ? `The data at "${key}" does not exist.` : `The data at "${key}.${path}" does not exist.`;
+    }
+
+    case CommonIdentifiers.MissingValue:
+      return 'The "value" parameter was not found.';
+
+    default:
+      return null;
+  }
+}

--- a/src/lib/functions/resolveCommonIdentifier.ts
+++ b/src/lib/functions/resolveCommonIdentifier.ts
@@ -14,7 +14,7 @@ export function resolveCommonIdentifier(identifier: string, metadata: Record<str
 
       return path.length === 0
         ? `The data at "${key}" is invalid. Expected type: ${type.toUpperCase()}`
-        : `The data at "${key}.${path}" is invalid. Expected type: ${type.toUpperCase()}`;
+        : `The data at "${key}.${path.join('.')}" is invalid. Expected type: ${type.toUpperCase()}`;
     }
 
     case CommonIdentifiers.InvalidValueType: {
@@ -31,7 +31,7 @@ export function resolveCommonIdentifier(identifier: string, metadata: Record<str
       if (typeof key === 'string') return null;
       if (!Array.isArray(path)) return null;
 
-      return path.length === 0 ? `The data at "${key}" does not exist.` : `The data at "${key}.${path}" does not exist.`;
+      return path.length === 0 ? `The data at "${key}" does not exist.` : `The data at "${key}.${path.join('.')}" does not exist.`;
     }
 
     case CommonIdentifiers.MissingValue:

--- a/src/lib/functions/validators/payloads/WithData.ts
+++ b/src/lib/functions/validators/payloads/WithData.ts
@@ -1,0 +1,5 @@
+import type { Payload } from '../../../types';
+
+export function isPayloadWithData<Value>(payload: Payload): payload is Payload.WithData<Value> {
+  return 'data' in payload;
+}

--- a/src/lib/functions/validators/payloads/index.ts
+++ b/src/lib/functions/validators/payloads/index.ts
@@ -5,3 +5,4 @@ export * from './Map';
 export * from './Partition';
 export * from './Remove';
 export * from './Some';
+export * from './WithData';

--- a/src/lib/structures/Josh.ts
+++ b/src/lib/structures/Josh.ts
@@ -643,21 +643,6 @@ export class Josh<StoredValue = unknown> {
   }
 
   /**
-   * Get a value using a key.
-   * @since 2.0.0
-   * @param key A key at which a value is.
-   * @returns The value gotten or null.
-   *
-   * @example
-   * ```javascript
-   * await josh.set('key', 'value');
-   *
-   * await josh.get('key'); // 'value'
-   * ```
-   */
-  public async get(key: string): Promise<StoredValue | null>;
-
-  /**
    * Get a value using a key and/or path.
    * @since 2.0.0
    * @param keyPath A key and/or path at which a value is.

--- a/src/lib/structures/Josh.ts
+++ b/src/lib/structures/Josh.ts
@@ -1623,7 +1623,7 @@ export class Josh<StoredValue = unknown> {
 
     switch (identifier) {
       case Josh.Identifiers.InvalidProvider:
-        return 'The "provider" option must extend the exported "JoshProvider" class';
+        return 'The "provider" option must extend the exported "JoshProvider" class to ensure compatibility, but continuing anyway.';
 
       case Josh.Identifiers.LegacyDeprecation:
         return 'You have imported data from a deprecated legacy format. This will be removed in the next semver major version.';

--- a/src/lib/structures/Josh.ts
+++ b/src/lib/structures/Josh.ts
@@ -2,8 +2,9 @@ import { Awaitable, isFunction, isPrimitive, Primitive } from '@sapphire/utiliti
 import { emitWarning } from 'process';
 import type { CoreAutoEnsure } from '../../middlewares/CoreAutoEnsure';
 import { JoshError, JoshErrorOptions } from '../errors';
-import { convertLegacyExportJSON, isLegacyExportJSON } from '../functions';
-import { BuiltInMiddleware, KeyPath, KeyPathJSON, MathOperator, Method, Path, Payload, Payloads, Trigger } from '../types';
+import { convertLegacyExportJSON, isLegacyExportJSON, resolveCommonIdentifier } from '../functions';
+import { isPayloadWithData } from '../functions/validators/payloads/WithData';
+import { BuiltInMiddleware, CommonIdentifiers, KeyPath, KeyPathJSON, MathOperator, Method, Path, Payload, Payloads, Trigger } from '../types';
 import { MapProvider } from './default-provider/MapProvider';
 import { JoshProvider } from './JoshProvider';
 import { Middleware } from './Middleware';
@@ -65,18 +66,12 @@ export class Josh<StoredValue = unknown> {
 
     this.options = options;
 
-    if (!name) throw this.error({ identifier: Josh.Identifiers.MissingName, message: 'The "name" option is required to initiate a Josh instance.' });
+    if (!name) throw this.error({ identifier: Josh.Identifiers.MissingName });
 
     this.name = name;
     this.provider = provider ?? new MapProvider<StoredValue>({});
 
-    if (!(this.provider instanceof JoshProvider))
-      emitWarning(
-        this.error({
-          identifier: Josh.Identifiers.InvalidProvider,
-          message: 'The "provider" option must extend the exported "JoshProvider" class.'
-        })
-      );
+    if (!(this.provider instanceof JoshProvider)) emitWarning(this.error({ identifier: Josh.Identifiers.InvalidProvider }));
 
     this.middlewares = new MiddlewareStore({ instance: this });
   }
@@ -128,11 +123,7 @@ export class Josh<StoredValue = unknown> {
   public use<P extends Payload>(optionsOrInstance: Josh.UseMiddlewareOptions | Middleware<StoredValue>, hook?: (payload: P) => Awaitable<P>): this {
     if (optionsOrInstance instanceof Middleware) this.middlewares.set(optionsOrInstance.name, optionsOrInstance);
     else {
-      if (hook === undefined)
-        throw this.error({
-          identifier: Josh.Identifiers.UseMiddlewareHookNotFound,
-          message: 'The "hook" parameter for middleware was not found.'
-        });
+      if (hook === undefined) throw this.error({ identifier: Josh.Identifiers.UseMiddlewareHookNotFound });
 
       const { name, position, trigger, method } = optionsOrInstance;
       const options: Middleware.Options = { name, position, conditions: { pre: [], post: [] } };
@@ -141,7 +132,6 @@ export class Josh<StoredValue = unknown> {
       if (trigger !== undefined && method !== undefined) options.conditions[trigger === Trigger.PreProvider ? 'pre' : 'post'].push(method);
 
       Object.defineProperty(middleware, method === undefined ? 'run' : method, { value: hook });
-
       this.middlewares.set(middleware.name, middleware);
     }
 
@@ -166,7 +156,7 @@ export class Josh<StoredValue = unknown> {
     for (const middleware of this.middlewares.array()) await middleware.run(payload);
     for (const middleware of this.middlewares.getPreMiddlewares(Method.AutoKey)) payload = await middleware[Method.AutoKey](payload);
 
-    if (!this.isPayloadWithData<string>(payload)) payload = await this.provider[Method.AutoKey](payload);
+    if (!isPayloadWithData<string>(payload)) payload = await this.provider[Method.AutoKey](payload);
 
     payload.trigger = Trigger.PostProvider;
 
@@ -175,7 +165,7 @@ export class Josh<StoredValue = unknown> {
     for (const middleware of this.middlewares.array()) await middleware.run(payload);
     for (const middleware of this.middlewares.getPostMiddlewares(Method.AutoKey)) payload = await middleware[Method.AutoKey](payload);
 
-    if (this.isPayloadWithData<string>(payload)) return payload.data;
+    if (isPayloadWithData<string>(payload)) return payload.data;
 
     throw this.providerFailedError;
   }
@@ -183,7 +173,7 @@ export class Josh<StoredValue = unknown> {
   /**
    * Clears all stored values from the provider.
    *
-   * NOTE: This deletes **all** data and cannot be reversed.
+   * NOTE: This deletes *all* data and cannot be reversed.
    * @since 2.0.0
    * @returns The {@link Josh} instance.
    *
@@ -265,7 +255,7 @@ export class Josh<StoredValue = unknown> {
    * ```
    */
   public async dec(keyPath: KeyPath): Promise<this> {
-    const [key, path] = this.getKeyPath(keyPath);
+    const [key, path] = this.resolveKeyPath(keyPath);
     let payload: Payloads.Dec = { method: Method.Dec, trigger: Trigger.PreProvider, key, path };
 
     for (const middleware of this.middlewares.array()) await middleware.run(payload);
@@ -334,7 +324,7 @@ export class Josh<StoredValue = unknown> {
    * ```
    */
   public async delete(keyPath: KeyPath): Promise<this> {
-    const [key, path] = this.getKeyPath(keyPath);
+    const [key, path] = this.resolveKeyPath(keyPath);
     let payload: Payloads.Delete = { method: Method.Delete, trigger: Trigger.PreProvider, key, path };
 
     for (const middleware of this.middlewares.array()) await middleware.run(payload);
@@ -393,7 +383,7 @@ export class Josh<StoredValue = unknown> {
     for (const middleware of this.middlewares.array()) await middleware.run(payload);
     for (const middleware of this.middlewares.getPreMiddlewares(Method.Ensure)) payload = await middleware[Method.Ensure](payload);
 
-    if (!this.isPayloadWithData<StoredValue>(payload)) payload = await this.provider[Method.Ensure](payload);
+    if (!isPayloadWithData<StoredValue>(payload)) payload = await this.provider[Method.Ensure](payload);
 
     payload.trigger = Trigger.PostProvider;
 
@@ -402,7 +392,7 @@ export class Josh<StoredValue = unknown> {
     for (const middleware of this.middlewares.array()) await middleware.run(payload);
     for (const middleware of this.middlewares.getPostMiddlewares(Method.Ensure)) payload = await middleware[Method.Ensure](payload);
 
-    if (this.isPayloadWithData<StoredValue>(payload)) return payload.data;
+    if (isPayloadWithData<StoredValue>(payload)) return payload.data;
 
     throw this.providerFailedError;
   }
@@ -469,11 +459,7 @@ export class Josh<StoredValue = unknown> {
    */
   public async every(hook: Payload.Hook<StoredValue>): Promise<boolean>;
   public async every(pathOrHook: Path | Payload.Hook<StoredValue>, value?: Primitive): Promise<boolean> {
-    if (!isFunction(pathOrHook)) {
-      if (value === undefined) throw this.error({ identifier: Josh.Identifiers.EveryMissingValue, message: 'The "value" parameter was not found.' });
-      if (!isPrimitive(value))
-        throw this.error({ identifier: Josh.Identifiers.EveryInvalidValue, message: 'The "value" parameter must be a primitive type.' });
-    }
+    if (!isFunction(pathOrHook) && !isPrimitive(value)) throw this.error({ identifier: CommonIdentifiers.InvalidValueType }, { type: 'primitive' });
 
     let payload: Payloads.Every<StoredValue> = {
       method: Method.Every,
@@ -483,14 +469,14 @@ export class Josh<StoredValue = unknown> {
 
     if (isFunction(pathOrHook)) payload.hook = pathOrHook;
     else {
-      payload.path = this.getPath(pathOrHook);
+      payload.path = this.resolvePath(pathOrHook);
       payload.value;
     }
 
     for (const middleware of this.middlewares.array()) await middleware.run(payload);
     for (const middleware of this.middlewares.getPreMiddlewares(Method.Every)) payload = await middleware[Method.Every](payload);
 
-    if (!this.isPayloadWithData<boolean>(payload)) payload = await this.provider[Method.Every](payload);
+    if (!isPayloadWithData<boolean>(payload)) payload = await this.provider[Method.Every](payload);
 
     payload.trigger = Trigger.PostProvider;
 
@@ -499,7 +485,7 @@ export class Josh<StoredValue = unknown> {
     for (const middleware of this.middlewares.array()) await middleware.run(payload);
     for (const middleware of this.middlewares.getPostMiddlewares(Method.Every)) payload = await middleware[Method.Every](payload);
 
-    if (this.isPayloadWithData<boolean>(payload)) return payload.data;
+    if (isPayloadWithData<boolean>(payload)) return payload.data;
 
     throw this.providerFailedError;
   }
@@ -553,11 +539,7 @@ export class Josh<StoredValue = unknown> {
     value?: Primitive,
     returnBulkType?: BulkType
   ): Promise<ReturnBulk<StoredValue>[BulkType]> {
-    if (!isFunction(pathOrHook)) {
-      if (value === undefined) throw this.error({ identifier: Josh.Identifiers.FilterMissingValue, message: 'The "value" parameter was not found.' });
-      if (!isPrimitive(value))
-        throw this.error({ identifier: Josh.Identifiers.FilterInvalidValue, message: 'The "value" parameter must be a primitive type.' });
-    }
+    if (!isFunction(pathOrHook) && !isPrimitive(value)) throw this.error({ identifier: CommonIdentifiers.InvalidValueType }, { type: 'primitive' });
 
     let payload: Payloads.Filter<StoredValue> = {
       method: Method.Filter,
@@ -567,14 +549,14 @@ export class Josh<StoredValue = unknown> {
 
     if (isFunction(pathOrHook)) payload.hook = pathOrHook;
     else {
-      payload.path = this.getPath(pathOrHook);
+      payload.path = this.resolvePath(pathOrHook);
       payload.value = value;
     }
 
     for (const middleware of this.middlewares.array()) await middleware.run(payload);
     for (const middleware of this.middlewares.getPreMiddlewares(Method.Filter)) payload = await middleware[Method.Filter](payload);
 
-    if (!this.isPayloadWithData<boolean>(payload)) payload = await this.provider[Method.Filter](payload);
+    if (!isPayloadWithData<boolean>(payload)) payload = await this.provider[Method.Filter](payload);
 
     payload.trigger = Trigger.PostProvider;
 
@@ -583,7 +565,7 @@ export class Josh<StoredValue = unknown> {
     for (const middleware of this.middlewares.array()) await middleware.run(payload);
     for (const middleware of this.middlewares.getPostMiddlewares(Method.Filter)) payload = await middleware[Method.Filter](payload);
 
-    if (this.isPayloadWithData<Record<string, StoredValue>>(payload)) return this.convertBulkData(payload.data, returnBulkType);
+    if (isPayloadWithData<Record<string, StoredValue>>(payload)) return this.convertBulkData(payload.data, returnBulkType);
 
     throw this.providerFailedError;
   }
@@ -629,11 +611,7 @@ export class Josh<StoredValue = unknown> {
    */
   public async find(hook: Payload.Hook<StoredValue>): Promise<[string, StoredValue] | [null, null]>;
   public async find(pathOrHook: Path | Payload.Hook<StoredValue>, value?: Primitive): Promise<[string, StoredValue] | [null, null]> {
-    if (!isFunction(pathOrHook)) {
-      if (value === undefined) throw this.error({ identifier: Josh.Identifiers.FindMissingValue, message: 'The "value" parameter was not found.' });
-      if (!isPrimitive(value))
-        throw this.error({ identifier: Josh.Identifiers.FindInvalidValue, message: 'The "value" parameter must be a primitive type.' });
-    }
+    if (!isFunction(pathOrHook) && !isPrimitive(value)) throw this.error({ identifier: CommonIdentifiers.InvalidValueType }, { type: 'primitive' });
 
     let payload: Payloads.Find<StoredValue> = {
       method: Method.Find,
@@ -643,14 +621,14 @@ export class Josh<StoredValue = unknown> {
 
     if (isFunction(pathOrHook)) payload.hook = pathOrHook;
     else {
-      payload.path = this.getPath(pathOrHook);
+      payload.path = this.resolvePath(pathOrHook);
       payload.value = value;
     }
 
     for (const middleware of this.middlewares.array()) await middleware.run(payload);
     for (const middleware of this.middlewares.getPreMiddlewares(Method.Find)) payload = await middleware[Method.Find](payload);
 
-    if (!this.isPayloadWithData<boolean>(payload)) payload = await this.provider[Method.Find](payload);
+    if (!isPayloadWithData<boolean>(payload)) payload = await this.provider[Method.Find](payload);
 
     payload.trigger = Trigger.PostProvider;
 
@@ -659,7 +637,7 @@ export class Josh<StoredValue = unknown> {
     for (const middleware of this.middlewares.array()) await middleware.run(payload);
     for (const middleware of this.middlewares.getPostMiddlewares(Method.Find)) payload = await middleware[Method.Find](payload);
 
-    if (this.isPayloadWithData<Record<string, StoredValue>>(payload)) return payload.data;
+    if (isPayloadWithData<Record<string, StoredValue>>(payload)) return payload.data;
 
     throw this.providerFailedError;
   }
@@ -703,13 +681,13 @@ export class Josh<StoredValue = unknown> {
    * ```
    */
   public async get<Value = StoredValue>(keyPath: KeyPath): Promise<Value | null> {
-    const [key, path] = this.getKeyPath(keyPath);
+    const [key, path] = this.resolveKeyPath(keyPath);
     let payload: Payloads.Get<Value> = { method: Method.Get, trigger: Trigger.PreProvider, key, path };
 
     for (const middleware of this.middlewares.array()) await middleware.run(payload);
     for (const middleware of this.middlewares.getPreMiddlewares(Method.Get)) payload = await middleware[Method.Get](payload);
 
-    if (!this.isPayloadWithData<boolean>(payload)) payload = await this.provider.get(payload);
+    if (!isPayloadWithData<boolean>(payload)) payload = await this.provider.get(payload);
 
     payload.trigger = Trigger.PostProvider;
 
@@ -751,7 +729,7 @@ export class Josh<StoredValue = unknown> {
     for (const middleware of this.middlewares.array()) await middleware.run(payload);
     for (const middleware of this.middlewares.getPreMiddlewares(Method.GetAll)) payload = await middleware[Method.GetAll](payload);
 
-    if (!this.isPayloadWithData<boolean>(payload)) payload = await this.provider.getAll(payload);
+    if (!isPayloadWithData<boolean>(payload)) payload = await this.provider.getAll(payload);
 
     payload.trigger = Trigger.PostProvider;
 
@@ -760,7 +738,7 @@ export class Josh<StoredValue = unknown> {
     for (const middleware of this.middlewares.array()) await middleware.run(payload);
     for (const middleware of this.middlewares.getPostMiddlewares(Method.GetAll)) payload = await middleware[Method.GetAll](payload);
 
-    if (this.isPayloadWithData<Record<string, StoredValue>>(payload)) return this.convertBulkData(payload.data, returnBulkType);
+    if (isPayloadWithData<Record<string, StoredValue>>(payload)) return this.convertBulkData(payload.data, returnBulkType);
 
     throw this.providerFailedError;
   }
@@ -789,7 +767,7 @@ export class Josh<StoredValue = unknown> {
     for (const middleware of this.middlewares.array()) await middleware.run(payload);
     for (const middleware of this.middlewares.getPreMiddlewares(Method.GetMany)) payload = await middleware[Method.GetMany](payload);
 
-    if (!this.isPayloadWithData<boolean>(payload)) payload = await this.provider[Method.GetMany](payload);
+    if (!isPayloadWithData<boolean>(payload)) payload = await this.provider[Method.GetMany](payload);
 
     payload.trigger = Trigger.PostProvider;
 
@@ -798,7 +776,7 @@ export class Josh<StoredValue = unknown> {
     for (const middleware of this.middlewares.array()) await middleware.run(payload);
     for (const middleware of this.middlewares.getPostMiddlewares(Method.GetMany)) payload = await middleware[Method.GetMany](payload);
 
-    if (this.isPayloadWithData<Record<string, StoredValue | null>>(payload)) return this.convertBulkData(payload.data, returnBulkType);
+    if (isPayloadWithData<Record<string, StoredValue | null>>(payload)) return this.convertBulkData(payload.data, returnBulkType);
 
     throw this.providerFailedError;
   }
@@ -834,13 +812,13 @@ export class Josh<StoredValue = unknown> {
    * ```
    */
   public async has(keyPath: KeyPath): Promise<boolean> {
-    const [key, path] = this.getKeyPath(keyPath);
+    const [key, path] = this.resolveKeyPath(keyPath);
     let payload: Payloads.Has = { method: Method.Has, trigger: Trigger.PreProvider, key, path };
 
     for (const middleware of this.middlewares.array()) await middleware.run(payload);
     for (const middleware of this.middlewares.getPreMiddlewares(Method.Has)) payload = await middleware[Method.Has](payload);
 
-    if (!this.isPayloadWithData<boolean>(payload)) payload = await this.provider.has(payload);
+    if (!isPayloadWithData<boolean>(payload)) payload = await this.provider.has(payload);
 
     payload.trigger = Trigger.PostProvider;
 
@@ -849,7 +827,7 @@ export class Josh<StoredValue = unknown> {
     for (const middleware of this.middlewares.array()) await middleware.run(payload);
     for (const middleware of this.middlewares.getPostMiddlewares(Method.Has)) payload = await middleware[Method.Has](payload);
 
-    if (this.isPayloadWithData<boolean>(payload)) return payload.data;
+    if (isPayloadWithData<boolean>(payload)) return payload.data;
 
     throw this.providerFailedError;
   }
@@ -906,7 +884,7 @@ export class Josh<StoredValue = unknown> {
    * ```
    */
   public async inc(keyPath: KeyPath): Promise<this> {
-    const [key, path] = this.getKeyPath(keyPath);
+    const [key, path] = this.resolveKeyPath(keyPath);
     let payload: Payloads.Inc = { method: Method.Inc, trigger: Trigger.PreProvider, key, path };
 
     for (const middleware of this.middlewares.array()) await middleware.run(payload);
@@ -941,7 +919,7 @@ export class Josh<StoredValue = unknown> {
     for (const middleware of this.middlewares.array()) await middleware.run(payload);
     for (const middleware of this.middlewares.getPreMiddlewares(Method.Keys)) payload = await middleware[Method.Keys](payload);
 
-    if (!this.isPayloadWithData<boolean>(payload)) payload = await this.provider.keys(payload);
+    if (!isPayloadWithData<boolean>(payload)) payload = await this.provider.keys(payload);
 
     payload.trigger = Trigger.PostProvider;
 
@@ -950,7 +928,7 @@ export class Josh<StoredValue = unknown> {
     for (const middleware of this.middlewares.array()) await middleware.run(payload);
     for (const middleware of this.middlewares.getPostMiddlewares(Method.Keys)) payload = await middleware[Method.Keys](payload);
 
-    if (this.isPayloadWithData<string[]>(payload)) return payload.data;
+    if (isPayloadWithData<string[]>(payload)) return payload.data;
 
     throw this.providerFailedError;
   }
@@ -990,12 +968,12 @@ export class Josh<StoredValue = unknown> {
     };
 
     if (isFunction(pathOrHook)) payload.hook = pathOrHook;
-    else payload.path = this.getPath(pathOrHook);
+    else payload.path = this.resolvePath(pathOrHook);
 
     for (const middleware of this.middlewares.array()) await middleware.run(payload);
     for (const middleware of this.middlewares.getPreMiddlewares(Method.Map)) payload = await middleware[Method.Map](payload);
 
-    if (!this.isPayloadWithData<boolean>(payload)) payload = await this.provider[Method.Map](payload);
+    if (!isPayloadWithData<boolean>(payload)) payload = await this.provider[Method.Map](payload);
 
     payload.trigger = Trigger.PostProvider;
 
@@ -1004,7 +982,7 @@ export class Josh<StoredValue = unknown> {
     for (const middleware of this.middlewares.array()) await middleware.run(payload);
     for (const middleware of this.middlewares.getPostMiddlewares(Method.Map)) payload = await middleware[Method.Map](payload);
 
-    if (this.isPayloadWithData<Value[]>(payload)) return payload.data;
+    if (isPayloadWithData<Value[]>(payload)) return payload.data;
 
     throw this.providerFailedError;
   }
@@ -1054,7 +1032,7 @@ export class Josh<StoredValue = unknown> {
    * ```
    */
   public async math(keyPath: KeyPath, operator: MathOperator, operand: number): Promise<this> {
-    const [key, path] = this.getKeyPath(keyPath);
+    const [key, path] = this.resolveKeyPath(keyPath);
     let payload: Payloads.Math = { method: Method.Math, trigger: Trigger.PreProvider, key, path, operator, operand };
 
     for (const middleware of this.middlewares.array()) await middleware.run(payload);
@@ -1120,12 +1098,7 @@ export class Josh<StoredValue = unknown> {
     value?: Primitive,
     returnBulkType?: BulkType
   ): Promise<[ReturnBulk<StoredValue>[BulkType], ReturnBulk<StoredValue>[BulkType]]> {
-    if (!isFunction(pathOrHook)) {
-      if (value === undefined)
-        throw this.error({ identifier: Josh.Identifiers.PartitionMissingValue, message: 'The "value" parameter was not found.' });
-      if (!isPrimitive(value))
-        throw this.error({ identifier: Josh.Identifiers.PartitionInvalidValue, message: 'The "value" parameter must be a primitive type.' });
-    }
+    if (!isFunction(pathOrHook) && !isPrimitive(value)) throw this.error({ identifier: CommonIdentifiers.InvalidValueType }, { type: 'primitive' });
 
     let payload: Payloads.Partition<StoredValue> = {
       method: Method.Partition,
@@ -1135,14 +1108,14 @@ export class Josh<StoredValue = unknown> {
 
     if (isFunction(pathOrHook)) payload.hook = pathOrHook;
     else {
-      payload.path = this.getPath(pathOrHook);
+      payload.path = this.resolvePath(pathOrHook);
       payload.value = value;
     }
 
     for (const middleware of this.middlewares.array()) await middleware.run(payload);
     for (const middleware of this.middlewares.getPreMiddlewares(Method.Partition)) payload = await middleware[Method.Partition](payload);
 
-    if (!this.isPayloadWithData<boolean>(payload)) payload = await this.provider[Method.Partition](payload);
+    if (!isPayloadWithData<boolean>(payload)) payload = await this.provider[Method.Partition](payload);
 
     payload.trigger = Trigger.PostProvider;
 
@@ -1151,7 +1124,7 @@ export class Josh<StoredValue = unknown> {
     for (const middleware of this.middlewares.array()) await middleware.run(payload);
     for (const middleware of this.middlewares.getPostMiddlewares(Method.Partition)) payload = await middleware[Method.Partition](payload);
 
-    if (this.isPayloadWithData<Payloads.Partition.Data<StoredValue>>(payload)) {
+    if (isPayloadWithData<Payloads.Partition.Data<StoredValue>>(payload)) {
       const { truthy, falsy } = payload.data;
 
       return [this.convertBulkData(truthy, returnBulkType), this.convertBulkData(falsy, returnBulkType)];
@@ -1189,7 +1162,7 @@ export class Josh<StoredValue = unknown> {
    * ```
    */
   public async push<Value = StoredValue>(keyPath: KeyPath, value: Value): Promise<this> {
-    const [key, path] = this.getKeyPath(keyPath);
+    const [key, path] = this.resolveKeyPath(keyPath);
     let payload: Payloads.Push<Value> = { method: Method.Push, trigger: Trigger.PreProvider, key, path, value };
 
     for (const middleware of this.middlewares.array()) await middleware.run(payload);
@@ -1218,7 +1191,7 @@ export class Josh<StoredValue = unknown> {
     for (const middleware of this.middlewares.array()) await middleware.run(payload);
     for (const middleware of this.middlewares.getPreMiddlewares(Method.Random)) payload = await middleware[Method.Random](payload);
 
-    if (!this.isPayloadWithData<boolean>(payload)) payload = await this.provider[Method.Random](payload);
+    if (!isPayloadWithData<boolean>(payload)) payload = await this.provider[Method.Random](payload);
 
     payload.trigger = Trigger.PostProvider;
 
@@ -1227,7 +1200,7 @@ export class Josh<StoredValue = unknown> {
     for (const middleware of this.middlewares.array()) await middleware.run(payload);
     for (const middleware of this.middlewares.getPostMiddlewares(Method.Random)) payload = await middleware[Method.Random](payload);
 
-    if (this.isPayloadWithData<StoredValue[]>(payload)) return payload.data.length ? payload.data : null;
+    if (isPayloadWithData<StoredValue[]>(payload)) return payload.data.length ? payload.data : null;
 
     throw this.providerFailedError;
   }
@@ -1251,14 +1224,14 @@ export class Josh<StoredValue = unknown> {
    * await josh.randomKey(); // null
    * ```
    */
-  public async randomKey(options?: Josh.RandomOptions): Promise<string[] | null> {
-    const { count = 1, duplicates = true } = options ?? {};
+  public async randomKey(options: Josh.RandomOptions = {}): Promise<string[] | null> {
+    const { count = 1, duplicates = true } = options;
     let payload: Payloads.RandomKey = { method: Method.RandomKey, trigger: Trigger.PreProvider, count, duplicates };
 
     for (const middleware of this.middlewares.array()) await middleware.run(payload);
     for (const middleware of this.middlewares.getPreMiddlewares(Method.RandomKey)) payload = await middleware[Method.RandomKey](payload);
 
-    if (!this.isPayloadWithData<boolean>(payload)) payload = await this.provider.randomKey(payload);
+    if (!isPayloadWithData<boolean>(payload)) payload = await this.provider.randomKey(payload);
 
     payload.trigger = Trigger.PostProvider;
 
@@ -1267,7 +1240,7 @@ export class Josh<StoredValue = unknown> {
     for (const middleware of this.middlewares.array()) await middleware.run(payload);
     for (const middleware of this.middlewares.getPostMiddlewares(Method.RandomKey)) payload = await middleware[Method.RandomKey](payload);
 
-    if (this.isPayloadWithData<string[]>(payload)) return payload.data.length ? payload.data : null;
+    if (isPayloadWithData<string[]>(payload)) return payload.data.length ? payload.data : null;
 
     throw this.providerFailedError;
   }
@@ -1308,12 +1281,10 @@ export class Josh<StoredValue = unknown> {
    */
   public async remove<Value = StoredValue>(keyPath: KeyPath, hook: Payload.Hook<Value>): Promise<this>;
   public async remove<Value = StoredValue>(keyPath: KeyPath, valueOrHook: Primitive | Payload.Hook<Value>): Promise<this> {
-    const [key, path] = this.getKeyPath(keyPath);
+    const [key, path] = this.resolveKeyPath(keyPath);
 
-    if (!isFunction(valueOrHook)) {
-      if (!isPrimitive(valueOrHook))
-        throw this.error({ identifier: Josh.Identifiers.RemoveInvalidValue, message: 'The "value" parameter was not of a primitive type.' });
-    }
+    if (!isFunction(valueOrHook) && !isPrimitive(valueOrHook))
+      throw this.error({ identifier: CommonIdentifiers.InvalidValueType }, { type: 'primitive' });
 
     let payload: Payloads.Remove<Value> = {
       method: Method.Remove,
@@ -1361,7 +1332,7 @@ export class Josh<StoredValue = unknown> {
    * ```
    */
   public async set<Value = StoredValue>(keyPath: KeyPath, value: Value): Promise<this> {
-    const [key, path] = this.getKeyPath(keyPath);
+    const [key, path] = this.resolveKeyPath(keyPath);
     let payload: Payloads.Set<Value> = { method: Method.Set, trigger: Trigger.PreProvider, key, path, value };
 
     for (const middleware of this.middlewares.array()) await middleware.run(payload);
@@ -1378,14 +1349,14 @@ export class Josh<StoredValue = unknown> {
     return this;
   }
 
-  public async setMany<Value = StoredValue>(entries: [KeyPath, Value][], overwrite = true): Promise<this> {
-    let payload: Payloads.SetMany<Value> = {
+  public async setMany(entries: [KeyPath, unknown][], overwrite = true): Promise<this> {
+    let payload: Payloads.SetMany = {
       method: Method.SetMany,
       trigger: Trigger.PreProvider,
       entries: entries.map(([keyPath, value]) => {
-        const [key, path] = this.getKeyPath(keyPath);
+        const [key, path] = this.resolveKeyPath(keyPath);
 
-        return [{ key, path: this.getPath(path) }, value];
+        return [{ key, path: this.resolvePath(path) }, value];
       }),
       overwrite
     };
@@ -1420,7 +1391,7 @@ export class Josh<StoredValue = unknown> {
     for (const middleware of this.middlewares.array()) await middleware.run(payload);
     for (const middleware of this.middlewares.getPreMiddlewares(Method.Size)) payload = await middleware[Method.Size](payload);
 
-    if (!this.isPayloadWithData<boolean>(payload)) payload = await this.provider[Method.Size](payload);
+    if (!isPayloadWithData<boolean>(payload)) payload = await this.provider[Method.Size](payload);
 
     payload.trigger = Trigger.PostProvider;
 
@@ -1429,7 +1400,7 @@ export class Josh<StoredValue = unknown> {
     for (const middleware of this.middlewares.array()) await middleware.run(payload);
     for (const middleware of this.middlewares.getPostMiddlewares(Method.Size)) payload = await middleware[Method.Size](payload);
 
-    if (this.isPayloadWithData<number>(payload)) return payload.data;
+    if (isPayloadWithData<number>(payload)) return payload.data;
 
     throw this.providerFailedError;
   }
@@ -1474,11 +1445,7 @@ export class Josh<StoredValue = unknown> {
    */
   public async some(hook: Payload.Hook<StoredValue>): Promise<boolean>;
   public async some(pathOrHook: Path | Payload.Hook<StoredValue>, value?: Primitive): Promise<boolean> {
-    if (!isFunction(pathOrHook)) {
-      if (value === undefined) throw this.error({ identifier: Josh.Identifiers.SomeMissingValue, message: 'The "value" parameter was not found.' });
-      if (!isPrimitive(value))
-        throw this.error({ identifier: Josh.Identifiers.SomeInvalidValue, message: 'The "value" parameter must be a primitive type.' });
-    }
+    if (!isFunction(pathOrHook) && !isPrimitive(value)) throw this.error({ identifier: CommonIdentifiers.InvalidValueType }, { type: 'primitive' });
 
     let payload: Payloads.Some<StoredValue> = {
       method: Method.Some,
@@ -1488,14 +1455,14 @@ export class Josh<StoredValue = unknown> {
 
     if (isFunction(pathOrHook)) payload.hook = pathOrHook;
     else {
-      payload.path = this.getPath(pathOrHook);
+      payload.path = this.resolvePath(pathOrHook);
       payload.value = value;
     }
 
     for (const middleware of this.middlewares.array()) await middleware.run(payload);
     for (const middleware of this.middlewares.getPreMiddlewares(Method.Some)) payload = await middleware[Method.Some](payload);
 
-    if (!this.isPayloadWithData<boolean>(payload)) payload = await this.provider[Method.Some](payload);
+    if (!isPayloadWithData<boolean>(payload)) payload = await this.provider[Method.Some](payload);
 
     payload.trigger = Trigger.PostProvider;
 
@@ -1504,7 +1471,7 @@ export class Josh<StoredValue = unknown> {
     for (const middleware of this.middlewares.array()) await middleware.run(payload);
     for (const middleware of this.middlewares.getPostMiddlewares(Method.Some)) payload = await middleware[Method.Some](payload);
 
-    if (this.isPayloadWithData<boolean>(payload)) return payload.data;
+    if (isPayloadWithData<boolean>(payload)) return payload.data;
 
     throw this.providerFailedError;
   }
@@ -1522,9 +1489,8 @@ export class Josh<StoredValue = unknown> {
    * await josh.update('key', (value) => value.toUpperCase()); // 'VALUE'
    * ```
    */
-  public async update<Value = StoredValue>(keyPath: KeyPath, hook: Payload.Hook<StoredValue, Value>): Promise<this> {
-    const [key, path] = this.getKeyPath(keyPath);
-    let payload: Payloads.Update<StoredValue, Value> = { method: Method.Update, trigger: Trigger.PreProvider, key, path, hook };
+  public async update<Value = StoredValue>(key: string, hook: Payload.Hook<StoredValue, Value>): Promise<this> {
+    let payload: Payloads.Update<StoredValue, Value> = { method: Method.Update, trigger: Trigger.PreProvider, key, hook };
 
     for (const middleware of this.middlewares.array()) await middleware.run(payload);
     for (const middleware of this.middlewares.getPreMiddlewares(Method.Update)) payload = await middleware[Method.Update](payload);
@@ -1559,7 +1525,7 @@ export class Josh<StoredValue = unknown> {
     for (const middleware of this.middlewares.array()) await middleware.run(payload);
     for (const middleware of this.middlewares.getPreMiddlewares(Method.Values)) payload = await middleware[Method.Values](payload);
 
-    if (!this.isPayloadWithData<boolean>(payload)) payload = await this.provider.values(payload);
+    if (!isPayloadWithData<boolean>(payload)) payload = await this.provider.values(payload);
 
     payload.trigger = Trigger.PostProvider;
 
@@ -1568,7 +1534,7 @@ export class Josh<StoredValue = unknown> {
     for (const middleware of this.middlewares.array()) await middleware.run(payload);
     for (const middleware of this.middlewares.getPostMiddlewares(Method.Values)) payload = await middleware[Method.Values](payload);
 
-    if (this.isPayloadWithData<StoredValue[]>(payload)) return payload.data;
+    if (isPayloadWithData<StoredValue[]>(payload)) return payload.data;
 
     throw this.providerFailedError;
   }
@@ -1612,6 +1578,10 @@ export class Josh<StoredValue = unknown> {
     };
   }
 
+  private get providerFailedError(): JoshError {
+    return this.error({ identifier: Josh.Identifiers.ProviderDataFailed });
+  }
+
   /** A private method for converting bulk data.
    * @since 2.0.0
    * @private
@@ -1641,28 +1611,73 @@ export class Josh<StoredValue = unknown> {
     }
   }
 
-  private getKeyPath(keyPath: KeyPath): [string, string[]] {
-    if (typeof keyPath === 'object') return [keyPath.key, this.getPath(keyPath.path ?? [])];
+  /**
+   * A private method to create a JoshError and resolving an identifier.
+   * @since 2.0.0
+   * @param options The options to create the error.
+   * @param metadata The metadata to add to resolving the identifier.
+   * @returns The error.
+   */
+  private error(options: JoshErrorOptions, metadata: Record<string, string> = {}): JoshError {
+    if ('message' in options) return new JoshError(options);
+
+    return new JoshError({ ...options, message: this.resolveIdentifier(options.identifier, metadata) });
+  }
+
+  /**
+   * A private method to resolve an identifier.
+   * @since 2.0.0
+   * @param identifier The identifier to resolve.
+   * @param metadata The metadata to add to resolving the identifier.
+   * @returns The resolved identifier message.
+   */
+  private resolveIdentifier(identifier: string, metadata: Record<string, string>): string {
+    const result = resolveCommonIdentifier(identifier, metadata);
+
+    if (result !== null) return result;
+
+    switch (identifier) {
+      case Josh.Identifiers.InvalidProvider:
+        return 'The "provider" option must extend the exported "JoshProvider" class';
+
+      case Josh.Identifiers.LegacyDeprecation:
+        return 'You have imported data from a deprecated legacy format. This will be removed in the next semver major version.';
+
+      case Josh.Identifiers.MissingName:
+        return 'The "name" option is required to initiate a Josh instance.';
+
+      case Josh.Identifiers.ProviderDataFailed:
+        return 'The provider failed to return data.';
+
+      case Josh.Identifiers.UseMiddlewareHookNotFound:
+        return 'The "hook" parameter for middleware was not found.';
+    }
+
+    throw new Error(`Unknown identifier: ${identifier}`);
+  }
+
+  /**
+   * A private method for resolving a key and/or path.
+   * @since 2.0.0
+   * @param keyPath The key and/or path to resolve.
+   * @returns The resolved key and/or path.
+   */
+  private resolveKeyPath(keyPath: KeyPath): [string, string[]] {
+    if (typeof keyPath === 'object') return [keyPath.key, this.resolvePath(keyPath.path ?? [])];
 
     const [key, ...path] = keyPath.split('.');
 
     return [key, path];
   }
 
-  private getPath(path: Path): string[] {
+  /**
+   * A private method for resolving a path.
+   * @since 2.0.0
+   * @param path The path to resolve.
+   * @returns The resolved path.
+   */
+  private resolvePath(path: Path): string[] {
     return typeof path === 'string' ? path.split('.') : path;
-  }
-
-  private isPayloadWithData<Value>(payload: Payload): payload is Payload.WithData<Value> {
-    return 'data' in payload;
-  }
-
-  private get providerFailedError(): JoshError {
-    return this.error({ identifier: Josh.Identifiers.ProviderDataFailed, message: 'The provider failed to return data.' });
-  }
-
-  private error(options: JoshErrorOptions): JoshError {
-    return new JoshError(options);
   }
 
   /**
@@ -1678,10 +1693,7 @@ export class Josh<StoredValue = unknown> {
    * @param options The options to give all the instances.
    * @returns
    */
-  public static multi<Instances extends Record<string, Josh> = Record<string, Josh>>(
-    names: string[],
-    options: Omit<Josh.Options, 'name'> = {}
-  ): Instances {
+  public static multi<Instances extends Record<string, Josh> = Record<string, Josh>>(names: string[], options: Josh.Options = {}): Instances {
     const instances: Record<string, Josh> = {};
 
     for (const [name, instance] of names.map((name) => [name, new Josh({ ...options, name })]) as [string, Josh][]) instances[name] = instance;
@@ -1842,37 +1854,13 @@ export namespace Josh {
   }
 
   export enum Identifiers {
-    EveryInvalidValue = 'everyInvalidValue',
-
-    EveryMissingValue = 'everyMissingValue',
-
-    FilterInvalidValue = 'filterInvalidValue',
-
-    FilterMissingValue = 'filterMissingValue',
-
-    FindInvalidValue = 'findInvalidValue',
-
-    FindMissingValue = 'findMissingValue',
-
     InvalidProvider = 'invalidProvider',
 
     LegacyDeprecation = 'legacyDeprecation',
 
-    MiddlewareNotFound = 'middlewareNotFound',
-
     MissingName = 'missingName',
 
-    PartitionInvalidValue = 'partitionInvalidValue',
-
-    PartitionMissingValue = 'partitionMissingValue',
-
     ProviderDataFailed = 'providerDataFailed',
-
-    RemoveInvalidValue = 'removeInvalidValue',
-
-    SomeInvalidValue = 'someInvalidValue',
-
-    SomeMissingValue = 'someMissingValue',
 
     UseMiddlewareHookNotFound = 'useMiddlewareHookNotFound'
   }

--- a/src/lib/structures/JoshProvider.ts
+++ b/src/lib/structures/JoshProvider.ts
@@ -320,7 +320,7 @@ export abstract class JoshProvider<StoredValue = unknown> {
    * @param payload The payload sent by this provider's {@link Josh} instance.
    * @returns The payload (modified), originally sent by this provider's {@link Josh} instance.
    */
-  public abstract [Method.SetMany]<Value = StoredValue>(payload: Payloads.SetMany<Value>): Awaitable<Payloads.SetMany<Value>>;
+  public abstract [Method.SetMany](payload: Payloads.SetMany): Awaitable<Payloads.SetMany>;
 
   /**
    * @since 2.0.0

--- a/src/lib/structures/JoshProvider.ts
+++ b/src/lib/structures/JoshProvider.ts
@@ -92,40 +92,23 @@ export abstract class JoshProvider<StoredValue = unknown> {
    * @since 2.0.0
    * @param payload The payload sent by this provider's {@link Josh} instance.
    * @returns The payload (modified), originally sent by this provider's {@link Josh} instance.
-   *
-   * @example
-   * ```javascript
-   * // Clear the provider...
-   * await database.clear();
-   *
-   * // Return the payload...
-   * return payload;
-   * ```
    */
   public abstract [Method.Clear](payload: Payloads.Clear): Awaitable<Payloads.Clear>;
 
   /**
-   * Decrements an integer value by 1.
+   * Decrements a key or path in an entry by 1.
    *
    * An error should be set to the payload and immediately return, if any of the following occurs:
-   * - The key and/or path does not exist - {@link JoshProvider.CommonIdentifiers.MissingData}
-   * - The data is not an integer - {@link JoshProvider.CommonIdentifiers.InvalidDataType}
+   * - The key and/or path does not exist - `CommonIdentifiers.MissingData`
+   * - The data is not an integer - `CommonIdentifiers.InvalidDataType``
    * @since 2.0.0
    * @param payload The payload sent by this provider's {@link Josh} instance.
    * @returns The payload (modified), originally sent by this provider's {@link Josh} instance.
-   *
-   * @example
-   * ```javascript
-   * // Destructure the payload...
-   * const { key, path } = payload;
-   *
-   * // Get the value from the provider...
-   * const getPayload = this[Method.Get]({ method: Method.Get, key, path });
-   * ```
    */
   public abstract [Method.Dec](payload: Payloads.Dec): Awaitable<Payloads.Dec>;
 
   /**
+   * Deletes a key or path in an entry.
    * @since 2.0.0
    * @param payload The payload sent by this provider's {@link Josh} instance.
    * @returns The payload (modified), originally sent by this provider's {@link Josh} instance.
@@ -133,6 +116,7 @@ export abstract class JoshProvider<StoredValue = unknown> {
   public abstract [Method.Delete](payload: Payloads.Delete): Awaitable<Payloads.Delete>;
 
   /**
+   * Deletes multiple keys in the provider.
    * @since 2.0.0
    * @param payload The payload sent by this provider's {@link Josh} instance.
    * @returns The payload (modified), originally sent by this provider's {@link Josh} instance.
@@ -140,6 +124,10 @@ export abstract class JoshProvider<StoredValue = unknown> {
   public abstract [Method.DeleteMany](payload: Payloads.DeleteMany): Awaitable<Payloads.DeleteMany>;
 
   /**
+   * Ensures a key exists.
+   *
+   * If the key exists, it returns the value.
+   * If the key does not exist, it creates it and returns the default value.
    * @since 2.0.0
    * @param payload The payload sent by this provider's {@link Josh} instance.
    * @returns The payload (modified), originally sent by this provider's {@link Josh} instance.
@@ -147,6 +135,7 @@ export abstract class JoshProvider<StoredValue = unknown> {
   public abstract [Method.Ensure](payload: Payloads.Ensure<StoredValue>): Awaitable<Payloads.Ensure<StoredValue>>;
 
   /**
+   * Checks every stored value with a function.
    * @since 2.0.0
    * @param payload The payload sent by this provider's {@link Josh} instance.
    * @returns The payload (modified), originally sent by this provider's {@link Josh} instance.
@@ -154,6 +143,10 @@ export abstract class JoshProvider<StoredValue = unknown> {
   public abstract [Method.Every]<StoredValue>(payload: Payloads.Every.ByHook<StoredValue>): Awaitable<Payloads.Every.ByHook<StoredValue>>;
 
   /**
+   * Checks every stored value at a path against the given value.
+   *
+   * An error should be set to the payload and immediately return, if any of the following occurs:
+   * - The data at the path is not a primitive type - `CommonIdentifiers.InvalidDataType`
    * @since 2.0.0
    * @param payload The payload sent by this provider's {@link Josh} instance.
    * @returns The payload (modified), originally sent by this provider's {@link Josh} instance.
@@ -162,6 +155,7 @@ export abstract class JoshProvider<StoredValue = unknown> {
   public abstract [Method.Every]<StoredValue>(payload: Payloads.Every<StoredValue>): Awaitable<Payloads.Every<StoredValue>>;
 
   /**
+   * Filter stored values using a hook function.
    * @since 2.0.0
    * @param payload The payload sent by this provider's {@link Josh} instance.
    * @returns The payload (modified), originally sent by this provider's {@link Josh} instance.
@@ -169,6 +163,10 @@ export abstract class JoshProvider<StoredValue = unknown> {
   public abstract [Method.Filter](payload: Payloads.Filter.ByHook<StoredValue>): Awaitable<Payloads.Filter.ByHook<StoredValue>>;
 
   /**
+   * Filter stored values at a path against the given value.
+   *
+   * An error should be set to the payload and immediately return, if any of the following occurs:
+   * - The data at the path is not a primitive type - `CommonIdentifiers.InvalidDataType`
    * @since 2.0.0
    * @param payload The payload sent by this provider's {@link Josh} instance.
    * @returns The payload (modified), originally sent by this provider's {@link Josh} instance.
@@ -177,6 +175,7 @@ export abstract class JoshProvider<StoredValue = unknown> {
   public abstract [Method.Filter](payload: Payloads.Filter<StoredValue>): Awaitable<Payloads.Filter<StoredValue>>;
 
   /**
+   * Find a stored value using a hook function.
    * @since 2.0.0
    * @param payload The payload sent by this provider's {@link Josh} instance.
    * @returns The payload (modified), originally sent by this provider's {@link Josh} instance.
@@ -184,6 +183,10 @@ export abstract class JoshProvider<StoredValue = unknown> {
   public abstract [Method.Find](payload: Payloads.Find.ByHook<StoredValue>): Awaitable<Payloads.Find.ByHook<StoredValue>>;
 
   /**
+   * Find a stored value at a path against the given value.
+   *
+   * An error should be set to the payload and immediately return, if any of the following occurs:
+   * - The data at the path is not a primitive type - `CommonIdentifiers.InvalidDataType`
    * @since 2.0.0
    * @param payload The payload sent by this provider's {@link Josh} instance.
    * @returns The payload (modified), originally sent by this provider's {@link Josh} instance.
@@ -192,6 +195,7 @@ export abstract class JoshProvider<StoredValue = unknown> {
   public abstract [Method.Find](payload: Payloads.Find<StoredValue>): Awaitable<Payloads.Find<StoredValue>>;
 
   /**
+   * Get a value using a key and/or path.
    * @since 2.0.0
    * @param payload The payload sent by this provider's {@link Josh} instance.
    * @returns The payload (modified), originally sent by this provider's {@link Josh} instance.
@@ -199,6 +203,7 @@ export abstract class JoshProvider<StoredValue = unknown> {
   public abstract [Method.Get]<Value = StoredValue>(payload: Payloads.Get<Value>): Awaitable<Payloads.Get<Value>>;
 
   /**
+   * Gets all data from the provider.
    * @since 2.0.0
    * @param payload The payload sent by this provider's {@link Josh} instance.
    * @returns The payload (modified), originally sent by this provider's {@link Josh} instance.
@@ -206,6 +211,7 @@ export abstract class JoshProvider<StoredValue = unknown> {
   public abstract [Method.GetAll](payload: Payloads.GetAll<StoredValue>): Awaitable<Payloads.GetAll<StoredValue>>;
 
   /**
+   * Gets multiple keys from the provider.
    * @since 2.0.0
    * @param payload The payload sent by this provider's {@link Josh} instance.
    * @returns The payload (modified), originally sent by this provider's {@link Josh} instance.
@@ -213,6 +219,7 @@ export abstract class JoshProvider<StoredValue = unknown> {
   public abstract [Method.GetMany](payload: Payloads.GetMany<StoredValue>): Awaitable<Payloads.GetMany<StoredValue>>;
 
   /**
+   * Checks whether a key and/or path exists.
    * @since 2.0.0
    * @param payload The payload sent by this provider's {@link Josh} instance.
    * @returns The payload (modified), originally sent by this provider's {@link Josh} instance.
@@ -220,6 +227,11 @@ export abstract class JoshProvider<StoredValue = unknown> {
   public abstract [Method.Has](payload: Payloads.Has): Awaitable<Payloads.Has>;
 
   /**
+   * Increments a key or path in an entry by 1.
+   *
+   * An error should be set to the payload and immediately return, if any of the following occurs:
+   * - The key and/or path does not exist - `CommonIdentifiers.MissingData`
+   * - The data is not an integer - `CommonIdentifiers.InvalidDataType``
    * @since 2.0.0
    * @param payload The payload sent by this provider's {@link Josh} instance.
    * @returns The payload (modified), originally sent by this provider's {@link Josh} instance.
@@ -227,6 +239,7 @@ export abstract class JoshProvider<StoredValue = unknown> {
   public abstract [Method.Inc](payload: Payloads.Inc): Awaitable<Payloads.Inc>;
 
   /**
+   * Returns all keys in the provider.
    * @since 2.0.0
    * @param payload The payload sent by this provider's {@link Josh} instance.
    * @returns The payload (modified), originally sent by this provider's {@link Josh} instance.
@@ -234,6 +247,7 @@ export abstract class JoshProvider<StoredValue = unknown> {
   public abstract [Method.Keys](payload: Payloads.Keys): Awaitable<Payloads.Keys>;
 
   /**
+   * Maps all stored values using a hook function.
    * @since 2.0.0
    * @param payload The payload sent by this provider's {@link Josh} instance.
    * @returns The payload (modified), originally sent by this provider's {@link Josh} instance.
@@ -243,6 +257,10 @@ export abstract class JoshProvider<StoredValue = unknown> {
   ): Awaitable<Payloads.Map.ByHook<StoredValue, Value>>;
 
   /**
+   * Maps all stored values using a path.
+   *
+   * An error should be set to the payload and immediately return, if any of the following occurs:
+   * - The data at the path is not found - `CommonIdentifiers.MissingData`
    * @since 2.0.0
    * @param payload The payload sent by this provider's {@link Josh} instance.
    * @returns The payload (modified), originally sent by this provider's {@link Josh} instance.
@@ -251,6 +269,11 @@ export abstract class JoshProvider<StoredValue = unknown> {
   public abstract [Method.Map]<Value = StoredValue>(payload: Payloads.Map<StoredValue, Value>): Awaitable<Payloads.Map<StoredValue, Value>>;
 
   /**
+   * Executes math operations on a value with an operand at a specified key and/or path.
+   *
+   * An error should be set to the payload and immediately return, if any of the following occurs:
+   * - The key and/or path does not exist - `CommonIdentifiers.MissingData`
+   * - The data is not an integer - `CommonIdentifiers.InvalidDataType`
    * @since 2.0.0
    * @param payload The payload sent by this provider's {@link Josh} instance.
    * @returns The payload (modified), originally sent by this provider's {@link Josh} instance.
@@ -258,6 +281,7 @@ export abstract class JoshProvider<StoredValue = unknown> {
   public abstract [Method.Math](payload: Payloads.Math): Awaitable<Payloads.Math>;
 
   /**
+   * Filter stored values using a hook function and get both truthy and falsy results.
    * @since 2.0.0
    * @param payload The payload sent by this provider's {@link Josh} instance.
    * @returns The payload (modified), originally sent by this provider's {@link Josh} instance.
@@ -265,6 +289,11 @@ export abstract class JoshProvider<StoredValue = unknown> {
   public abstract [Method.Partition](payload: Payloads.Partition.ByHook<StoredValue>): Awaitable<Payloads.Partition.ByHook<StoredValue>>;
 
   /**
+   * Filter stored values using a path and get both truthy and falsy results.
+   *
+   * An error should be set to the payload and immediately return, if any of the following occurs:
+   * - The data at the path is not found - `CommonIdentifiers.MissingData`
+   * - The data at the path is not a primitive type - `CommonIdentifiers.InvalidDataType`
    * @since 2.0.0
    * @param payload The payload sent by this provider's {@link Josh} instance.
    * @returns The payload (modified), originally sent by this provider's {@link Josh} instance.
@@ -273,6 +302,11 @@ export abstract class JoshProvider<StoredValue = unknown> {
   public abstract [Method.Partition](payload: Payloads.Partition<StoredValue>): Awaitable<Payloads.Partition<StoredValue>>;
 
   /**
+   * Push a value to an array at a specified key and/or path.
+   *
+   * An error should be set to the payload and immediately return, if any of the following occurs:
+   * - The key and/or path does not exist - `CommonIdentifiers.MissingData`
+   * - The data at the path is not an array - `CommonIdentifiers.InvalidDataType`
    * @since 2.0.0
    * @param payload The payload sent by this provider's {@link Josh} instance.
    * @returns The payload (modified), originally sent by this provider's {@link Josh} instance.
@@ -280,6 +314,9 @@ export abstract class JoshProvider<StoredValue = unknown> {
   public abstract [Method.Push]<Value>(payload: Payloads.Push<Value>): Awaitable<Payloads.Push<Value>>;
 
   /**
+   * Gets random value(s) from the provider.
+   * Whether duplicates are allowed or not are controlled by {@link Payloads.Random.duplicates} option.
+   * The amount of values returned is controlled by {@link Payloads.Random.count} option.
    * @since 2.0.0
    * @param payload The payload sent by this provider's {@link Josh} instance.
    * @returns The payload (modified), originally sent by this provider's {@link Josh} instance.
@@ -287,6 +324,9 @@ export abstract class JoshProvider<StoredValue = unknown> {
   public abstract [Method.Random](payload: Payloads.Random<StoredValue>): Awaitable<Payloads.Random<StoredValue>>;
 
   /**
+   * Gets random key(s) from the provider.
+   * Whether duplicates are allowed or not are controlled by {@link Payloads.RandomKey.duplicates} option.
+   * The amount of keys returned is controlled by {@link Payloads.RandomKey.count} option.
    * @since 2.0.0
    * @param payload The payload sent by this provider's {@link Josh} instance.
    * @returns The payload (modified), originally sent by this provider's {@link Josh} instance.
@@ -301,6 +341,11 @@ export abstract class JoshProvider<StoredValue = unknown> {
   public abstract [Method.Remove]<StoredValue>(payload: Payloads.Remove.ByHook<StoredValue>): Awaitable<Payloads.Remove.ByHook<StoredValue>>;
 
   /**
+   * Removes an element from an array at a specified key and/or path.
+   *
+   * An error should be set to the payload and immediately return, if any of the following occurs:
+   * - The key and/or path does not exist - `CommonIdentifiers.MissingData`
+   * - The data at the path is not an array - `CommonIdentifiers.InvalidDataType`
    * @since 2.0.0
    * @param payload The payload sent by this provider's {@link Josh} instance.
    * @returns The payload (modified), originally sent by this provider's {@link Josh} instance.
@@ -309,6 +354,7 @@ export abstract class JoshProvider<StoredValue = unknown> {
   public abstract [Method.Remove]<StoredValue>(payload: Payloads.Remove<StoredValue>): Awaitable<Payloads.Remove<StoredValue>>;
 
   /**
+   * Sets a value at a specified key and/or path.
    * @since 2.0.0
    * @param payload The payload sent by this provider's {@link Josh} instance.
    * @returns The payload (modified), originally sent by this provider's {@link Josh} instance.
@@ -316,6 +362,7 @@ export abstract class JoshProvider<StoredValue = unknown> {
   public abstract [Method.Set]<Value = StoredValue>(payload: Payloads.Set<Value>): Awaitable<Payloads.Set<Value>>;
 
   /**
+   * Set many values at specified keys and/or paths.
    * @since 2.0.0
    * @param payload The payload sent by this provider's {@link Josh} instance.
    * @returns The payload (modified), originally sent by this provider's {@link Josh} instance.
@@ -323,6 +370,7 @@ export abstract class JoshProvider<StoredValue = unknown> {
   public abstract [Method.SetMany](payload: Payloads.SetMany): Awaitable<Payloads.SetMany>;
 
   /**
+   * Returns the amount of entries in the provider.
    * @since 2.0.0
    * @param payload The payload sent by this provider's {@link Josh} instance.
    * @returns The payload (modified), originally sent by this provider's {@link Josh} instance.
@@ -330,6 +378,7 @@ export abstract class JoshProvider<StoredValue = unknown> {
   public abstract [Method.Size](payload: Payloads.Size): Awaitable<Payloads.Size>;
 
   /**
+   * Identical to {@link JoshProvider.find}, but returns a boolean instead of a value.
    * @since 2.0.0
    * @param payload The payload sent by this provider's {@link Josh} instance.
    * @returns The payload (modified), originally sent by this provider's {@link Josh} instance.
@@ -337,6 +386,11 @@ export abstract class JoshProvider<StoredValue = unknown> {
   public abstract [Method.Some]<StoredValue>(payload: Payloads.Some.ByHook<StoredValue>): Awaitable<Payloads.Some.ByHook<StoredValue>>;
 
   /**
+   * Identical to {@link JoshProvider.find}, but returns a boolean instead of a value.
+   *
+   * An error should be set to the payload and immediately return, if any of the following occurs:
+   * - The path does not exist on an entry - `CommonIdentifiers.MissingData`
+   * - The data at the path is not a primitive type - `CommonIdentifiers.InvalidDataType`
    * @since 2.0.0
    * @param payload The payload sent by this provider's {@link Josh} instance.
    * @returns The payload (modified), originally sent by this provider's {@link Josh} instance.
@@ -345,6 +399,10 @@ export abstract class JoshProvider<StoredValue = unknown> {
   public abstract [Method.Some]<StoredValue>(payload: Payloads.Some<StoredValue>): Awaitable<Payloads.Some<StoredValue>>;
 
   /**
+   * Updates a value with a function.
+   *
+   * An error should be set to the payload and immediately return, if any of the following occurs:
+   * - The key does not exist - `CommonIdentifiers.MissingData`
    * @since 2.0.0
    * @param payload The payload sent by this provider's {@link Josh} instance.
    * @returns The payload (modified), originally sent by this provider's {@link Josh} instance.
@@ -352,6 +410,7 @@ export abstract class JoshProvider<StoredValue = unknown> {
   public abstract [Method.Update]<Value>(payload: Payloads.Update<StoredValue, Value>): Awaitable<Payloads.Update<StoredValue, Value>>;
 
   /**
+   * Returns all entries in the provider.
    * @since 2.0.0
    * @param payload The payload sent by this provider's {@link Josh} instance.
    * @returns The payload (modified), originally sent by this provider's {@link Josh} instance.
@@ -370,6 +429,12 @@ export abstract class JoshProvider<StoredValue = unknown> {
     return new JoshProviderError({ ...options, message: this.resolveIdentifier(options.identifier, metadata) });
   }
 
+  /**
+   * Resolves an identifier.
+   * @param identifier The identifier to resolve.
+   * @param metadata The metadata to use.
+   * @returns The resolved identifier message.
+   */
   protected resolveIdentifier(identifier: string, metadata: Record<string, unknown>): string {
     const result = resolveCommonIdentifier(identifier, metadata);
 

--- a/src/lib/structures/JoshProvider.ts
+++ b/src/lib/structures/JoshProvider.ts
@@ -7,7 +7,7 @@ import type { Josh } from './Josh';
 /**
  * The base provider class. Extend this class to create your own provider.
  *
- * NOTE: If you want an example of how to use this class please see `src/lib/structures/defaultProvider/MapProvider.ts`
+ * NOTE: If you want an example of how to use this class please see `src/lib/structures/default-provider/MapProvider.ts`
  *
  * @see {@link JoshProvider.Options} for all options available to the JoshProvider class.
  *
@@ -68,7 +68,9 @@ export abstract class JoshProvider<StoredValue = unknown> {
   }
 
   /**
-   * Generates a unique automatic key. This key must be unique and cannot overlap other keys.
+   * Generates a unique automatic key.
+   * This key must be unique and cannot overlap other keys.
+   * Notice, there is not a set rule of how the key is generated or it's formatted.
    * @since 2.0.0
    * @param payload The payload sent by this provider's {@link Josh} instance.
    * @returns The payload (modified), originally sent by this provider's {@link Josh} instance.
@@ -88,7 +90,7 @@ export abstract class JoshProvider<StoredValue = unknown> {
   public abstract [Method.AutoKey](payload: Payloads.AutoKey): Awaitable<Payloads.AutoKey>;
 
   /**
-   * Clears the provider of it's data entries.
+   * Clears all data.
    * @since 2.0.0
    * @param payload The payload sent by this provider's {@link Josh} instance.
    * @returns The payload (modified), originally sent by this provider's {@link Josh} instance.
@@ -116,7 +118,7 @@ export abstract class JoshProvider<StoredValue = unknown> {
   public abstract [Method.Delete](payload: Payloads.Delete): Awaitable<Payloads.Delete>;
 
   /**
-   * Deletes multiple keys in the provider.
+   * Deletes multiple keys.
    * @since 2.0.0
    * @param payload The payload sent by this provider's {@link Josh} instance.
    * @returns The payload (modified), originally sent by this provider's {@link Josh} instance.
@@ -203,7 +205,7 @@ export abstract class JoshProvider<StoredValue = unknown> {
   public abstract [Method.Get]<Value = StoredValue>(payload: Payloads.Get<Value>): Awaitable<Payloads.Get<Value>>;
 
   /**
-   * Gets all data from the provider.
+   * Gets all data.
    * @since 2.0.0
    * @param payload The payload sent by this provider's {@link Josh} instance.
    * @returns The payload (modified), originally sent by this provider's {@link Josh} instance.
@@ -211,7 +213,7 @@ export abstract class JoshProvider<StoredValue = unknown> {
   public abstract [Method.GetAll](payload: Payloads.GetAll<StoredValue>): Awaitable<Payloads.GetAll<StoredValue>>;
 
   /**
-   * Gets multiple keys from the provider.
+   * Gets multiple keys.
    * @since 2.0.0
    * @param payload The payload sent by this provider's {@link Josh} instance.
    * @returns The payload (modified), originally sent by this provider's {@link Josh} instance.
@@ -239,7 +241,7 @@ export abstract class JoshProvider<StoredValue = unknown> {
   public abstract [Method.Inc](payload: Payloads.Inc): Awaitable<Payloads.Inc>;
 
   /**
-   * Returns all keys in the provider.
+   * Returns all keys.
    * @since 2.0.0
    * @param payload The payload sent by this provider's {@link Josh} instance.
    * @returns The payload (modified), originally sent by this provider's {@link Josh} instance.
@@ -314,7 +316,7 @@ export abstract class JoshProvider<StoredValue = unknown> {
   public abstract [Method.Push]<Value>(payload: Payloads.Push<Value>): Awaitable<Payloads.Push<Value>>;
 
   /**
-   * Gets random value(s) from the provider.
+   * Gets random value(s).
    * Whether duplicates are allowed or not are controlled by {@link Payloads.Random.duplicates} option.
    * The amount of values returned is controlled by {@link Payloads.Random.count} option.
    * @since 2.0.0
@@ -324,7 +326,7 @@ export abstract class JoshProvider<StoredValue = unknown> {
   public abstract [Method.Random](payload: Payloads.Random<StoredValue>): Awaitable<Payloads.Random<StoredValue>>;
 
   /**
-   * Gets random key(s) from the provider.
+   * Gets random key(s).
    * Whether duplicates are allowed or not are controlled by {@link Payloads.RandomKey.duplicates} option.
    * The amount of keys returned is controlled by {@link Payloads.RandomKey.count} option.
    * @since 2.0.0
@@ -370,7 +372,7 @@ export abstract class JoshProvider<StoredValue = unknown> {
   public abstract [Method.SetMany](payload: Payloads.SetMany): Awaitable<Payloads.SetMany>;
 
   /**
-   * Returns the amount of entries in the provider.
+   * Returns the count of entries.
    * @since 2.0.0
    * @param payload The payload sent by this provider's {@link Josh} instance.
    * @returns The payload (modified), originally sent by this provider's {@link Josh} instance.
@@ -410,7 +412,7 @@ export abstract class JoshProvider<StoredValue = unknown> {
   public abstract [Method.Update]<Value>(payload: Payloads.Update<StoredValue, Value>): Awaitable<Payloads.Update<StoredValue, Value>>;
 
   /**
-   * Returns all entries in the provider.
+   * Returns all stored values.
    * @since 2.0.0
    * @param payload The payload sent by this provider's {@link Josh} instance.
    * @returns The payload (modified), originally sent by this provider's {@link Josh} instance.

--- a/src/lib/structures/Middleware.ts
+++ b/src/lib/structures/Middleware.ts
@@ -188,7 +188,7 @@ export class Middleware<StoredValue = unknown> {
     return payload;
   }
 
-  public [Method.SetMany]<Value = StoredValue>(payload: Payloads.SetMany<Value>): Awaitable<Payloads.SetMany<Value>> {
+  public [Method.SetMany](payload: Payloads.SetMany): Awaitable<Payloads.SetMany> {
     return payload;
   }
 

--- a/src/lib/structures/default-provider/MapProvider.ts
+++ b/src/lib/structures/default-provider/MapProvider.ts
@@ -1,4 +1,4 @@
-import { isNumber, isPrimitive } from '@sapphire/utilities';
+import { isPrimitive } from '@sapphire/utilities';
 import { deleteProperty, getProperty, hasProperty, PROPERTY_NOT_FOUND, setProperty } from 'property-helpers';
 import {
   isEveryByHookPayload,
@@ -15,8 +15,9 @@ import {
   isRemoveByValuePayload,
   isSomeByHookPayload,
   isSomeByValuePayload
-} from '../../functions/validators';
-import { MathOperator, Method, Payloads } from '../../types';
+} from '../../functions';
+import { isPayloadWithData } from '../../functions/validators/payloads/WithData';
+import { CommonIdentifiers, MathOperator, Method, Payloads } from '../../types';
 import { JoshProvider } from '../JoshProvider';
 
 /**
@@ -27,19 +28,17 @@ export class MapProvider<StoredValue = unknown> extends JoshProvider<StoredValue
   /**
    * The [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) cache to store data.
    * @since 2.0.0
-   * @private
    */
   private cache = new Map<string, StoredValue>();
 
   /**
-   * A simple cache for the {@link MapProvider.autoKey} method.
+   * A simple cache for the autoKey.
    * @since 2.0.0
    */
   private autoKeyCount = 0;
 
   public [Method.AutoKey](payload: Payloads.AutoKey): Payloads.AutoKey {
     this.autoKeyCount++;
-
     payload.data = this.autoKeyCount.toString();
 
     return payload;
@@ -54,30 +53,23 @@ export class MapProvider<StoredValue = unknown> extends JoshProvider<StoredValue
 
   public [Method.Dec](payload: Payloads.Dec): Payloads.Dec {
     const { key, path } = payload;
-    const { data } = this.get({ method: Method.Get, key, path });
+    const getPayload = this[Method.Get]({ method: Method.Get, key, path });
 
-    if (data === undefined) {
-      payload.error = this.error({
-        identifier: JoshProvider.CommonIdentifiers.DecMissingData,
-        message: path.length === 0 ? `The data at "${key}" does not exist.` : `The data at "${key}.${path.join('.')}" does not exist.`,
-        method: Method.Dec
-      });
+    if (!isPayloadWithData(getPayload))
+      return {
+        ...payload,
+        error: this.error({ identifier: CommonIdentifiers.MissingData, method: Method.Dec }, { key, path: path.join('.') })
+      };
 
-      return payload;
-    }
+    const { data } = getPayload;
 
-    if (typeof data !== 'number') {
-      payload.error = this.error({
-        identifier: JoshProvider.CommonIdentifiers.DecInvalidType,
-        message:
-          path.length === 0 ? `The data at "${key}" must be of type "number".` : `The data at "${key}.${path.join('.')}" must be of type "number".`,
-        method: Method.Dec
-      });
+    if (typeof data !== 'number')
+      return {
+        ...payload,
+        error: this.error({ identifier: CommonIdentifiers.InvalidDataType, method: Method.Dec }, { key, path: path.join('.'), type: 'number' })
+      };
 
-      return payload;
-    }
-
-    this.set({ method: Method.Set, key, path, value: data - 1 });
+    this[Method.Set]({ method: Method.Set, key, path, value: data - 1 });
 
     return payload;
   }
@@ -85,17 +77,8 @@ export class MapProvider<StoredValue = unknown> extends JoshProvider<StoredValue
   public [Method.Delete](payload: Payloads.Delete): Payloads.Delete {
     const { key, path } = payload;
 
-    if (path.length === 0) {
-      this.cache.delete(key);
-
-      return payload;
-    }
-
-    if (this.has({ method: Method.Has, key, path }).data) {
-      deleteProperty(this.cache.get(key), path);
-
-      return payload;
-    }
+    if (path.length === 0) this.cache.delete(key);
+    else if (this[Method.Has]({ method: Method.Has, key, path }).data) deleteProperty(this.cache.get(key), path);
 
     return payload;
   }
@@ -109,11 +92,12 @@ export class MapProvider<StoredValue = unknown> extends JoshProvider<StoredValue
   }
 
   public [Method.Ensure](payload: Payloads.Ensure<StoredValue>): Payloads.Ensure<StoredValue> {
-    const { key } = payload;
+    const { key, defaultValue } = payload;
 
-    if (!this.cache.has(key)) this.cache.set(key, payload.defaultValue);
+    payload.data = defaultValue;
 
-    Reflect.set(payload, 'data', this.cache.get(key));
+    if (this.cache.has(key)) payload.data = this.cache.get(key);
+    else this.cache.set(key, defaultValue);
 
     return payload;
   }
@@ -123,19 +107,14 @@ export class MapProvider<StoredValue = unknown> extends JoshProvider<StoredValue
   public async [Method.Every](payload: Payloads.Every<StoredValue>): Promise<Payloads.Every<StoredValue>> {
     payload.data = true;
 
-    if (this.cache.size === 0) {
-      payload.data = false;
-
-      return payload;
-    }
-
+    if (this.cache.size === 0) return payload;
     if (isEveryByHookPayload(payload)) {
       const { hook } = payload;
 
       for (const value of this.cache.values()) {
-        const everyValue = await hook(value);
+        const result = await hook(value);
 
-        if (everyValue) continue;
+        if (result) continue;
 
         payload.data = false;
       }
@@ -144,10 +123,15 @@ export class MapProvider<StoredValue = unknown> extends JoshProvider<StoredValue
     if (isEveryByValuePayload(payload)) {
       const { path, value } = payload;
 
-      for (const key of this.cache.keys()) {
-        const { data } = this.get({ method: Method.Get, key, path });
+      for (const [key, storedValue] of this.cache.entries()) {
+        const data = getProperty<StoredValue>(storedValue, path);
 
-        if (value === data) continue;
+        if (!isPrimitive(data))
+          return {
+            ...payload,
+            error: this.error({ identifier: CommonIdentifiers.InvalidDataType, method: Method.Every }, { key, type: 'primitive' })
+          };
+        if (data === value) continue;
 
         payload.data = false;
       }
@@ -165,31 +149,24 @@ export class MapProvider<StoredValue = unknown> extends JoshProvider<StoredValue
       const { hook } = payload;
 
       for (const [key, value] of this.cache.entries()) {
-        const filterValue = await hook(value);
+        const result = await hook(value);
 
-        if (!filterValue) continue;
-
-        payload.data[key] = value;
+        if (result) payload.data[key] = value;
       }
     }
 
     if (isFilterByValuePayload(payload)) {
       const { path, value } = payload;
 
-      if (!isPrimitive(value)) {
-        payload.error = this.error({
-          identifier: JoshProvider.CommonIdentifiers.FilterInvalidValue,
-          message: 'The "value" must be a primitive type.',
-          method: Method.Filter
-        });
-
-        return payload;
-      }
-
       for (const [key, storedValue] of this.cache.entries()) {
-        const data = getProperty(storedValue, path);
+        const data = getProperty<StoredValue>(storedValue, path);
 
-        if (data !== PROPERTY_NOT_FOUND) payload.data[key] = storedValue;
+        if (!isPrimitive(data))
+          return {
+            ...payload,
+            error: this.error({ identifier: CommonIdentifiers.InvalidDataType, method: Method.Filter }, { key, path, type: 'primitive' })
+          };
+        if (data === value) payload.data[key] = storedValue;
       }
     }
 
@@ -205,35 +182,32 @@ export class MapProvider<StoredValue = unknown> extends JoshProvider<StoredValue
       const { hook } = payload;
 
       for (const [key, value] of this.cache.entries()) {
-        const foundValue = await hook(value);
+        const result = await hook(value);
 
-        if (!foundValue) continue;
+        if (result) {
+          payload.data = [key, value];
 
-        payload.data = [key, value];
-
-        break;
+          break;
+        }
       }
     }
 
     if (isFindByValuePayload(payload)) {
       const { path, value } = payload;
 
-      if (!isPrimitive(value)) {
-        payload.error = this.error({
-          identifier: JoshProvider.CommonIdentifiers.FindInvalidValue,
-          message: 'The "value" must be of type primitive.',
-          method: Method.Find
-        });
-
-        return payload;
-      }
-
       for (const [key, storedValue] of this.cache.entries()) {
-        if (payload.data[0] !== null && payload.data[1] !== null) break;
+        const data = getProperty<StoredValue>(storedValue, path);
 
-        const data = getProperty(storedValue, path);
+        if (!isPrimitive(data))
+          return {
+            ...payload,
+            error: this.error({ identifier: CommonIdentifiers.InvalidDataType, method: Method.Find }, { key, path, type: 'primitive' })
+          };
+        if (data === value) {
+          payload.data = [key, storedValue];
 
-        if (data !== PROPERTY_NOT_FOUND) payload.data = [key, storedValue];
+          break;
+        }
       }
     }
 
@@ -242,28 +216,21 @@ export class MapProvider<StoredValue = unknown> extends JoshProvider<StoredValue
 
   public [Method.Get]<Value = StoredValue>(payload: Payloads.Get<Value>): Payloads.Get<Value> {
     const { key, path } = payload;
+    const data = getProperty<Value>(this.cache.get(key), path);
 
-    const data = getProperty(this.cache.get(key), path);
-
-    if (data !== PROPERTY_NOT_FOUND) Reflect.set(payload, 'data', data);
+    if (data !== PROPERTY_NOT_FOUND) payload.data = data;
 
     return payload;
   }
 
   public [Method.GetAll](payload: Payloads.GetAll<StoredValue>): Payloads.GetAll<StoredValue> {
-    payload.data = {};
-
-    for (const [key, value] of this.cache.entries()) payload.data[key] = value;
+    payload.data = Array.from(this.cache.entries()).reduce((data, [key, value]) => ({ ...data, [key]: value }), {});
 
     return payload;
   }
 
   public [Method.GetMany](payload: Payloads.GetMany<StoredValue>): Payloads.GetMany<StoredValue> {
-    const { keys } = payload;
-
-    payload.data = {};
-
-    for (const key of keys) payload.data[key] = this.cache.get(key) ?? null;
+    payload.data = payload.keys.reduce((data, key) => ({ ...data, [key]: this.cache.get(key) ?? null }), {});
 
     return payload;
   }
@@ -271,37 +238,30 @@ export class MapProvider<StoredValue = unknown> extends JoshProvider<StoredValue
   public [Method.Has](payload: Payloads.Has): Payloads.Has {
     const { key, path } = payload;
 
-    payload.data = this.cache.has(key) ? (path.length === 0 ? true : hasProperty(this.cache.get(key)!, path)) : false;
+    payload.data = this.cache.has(key) && hasProperty(this.cache.get(key), path);
 
     return payload;
   }
 
   public [Method.Inc](payload: Payloads.Inc): Payloads.Inc {
     const { key, path } = payload;
-    const { data } = this.get({ method: Method.Get, key, path });
+    const getPayload = this[Method.Get]({ method: Method.Get, key, path });
 
-    if (data === undefined) {
-      payload.error = this.error({
-        identifier: JoshProvider.CommonIdentifiers.IncMissingData,
-        message: path.length === 0 ? `The data at "${key}" does not exist.` : `The data at "${key}.${path.join('.')}" does not exist.`,
-        method: Method.Inc
-      });
+    if (!isPayloadWithData(getPayload))
+      return {
+        ...payload,
+        error: this.error({ identifier: CommonIdentifiers.MissingData, method: Method.Inc }, { key, path })
+      };
 
-      return payload;
-    }
+    const { data } = getPayload;
 
-    if (typeof data !== 'number') {
-      payload.error = this.error({
-        identifier: JoshProvider.CommonIdentifiers.IncInvalidType,
-        message:
-          path.length === 0 ? `The data at "${key}" must be of type "number".` : `The data at "${key}.${path.join('.')}" must be of type "number".`,
-        method: Method.Inc
-      });
+    if (typeof data !== 'number')
+      return {
+        ...payload,
+        error: this.error({ identifier: CommonIdentifiers.InvalidDataType, method: Method.Inc })
+      };
 
-      return payload;
-    }
-
-    this.set({ method: Method.Set, key, path, value: data + 1 });
+    this[Method.Set]({ method: Method.Set, key, path, value: data + 1 });
 
     return payload;
   }
@@ -313,7 +273,6 @@ export class MapProvider<StoredValue = unknown> extends JoshProvider<StoredValue
   }
 
   public async [Method.Map]<Value = StoredValue>(payload: Payloads.Map.ByHook<StoredValue, Value>): Promise<Payloads.Map.ByHook<StoredValue, Value>>;
-
   public async [Method.Map]<Value = StoredValue>(payload: Payloads.Map.ByPath<Value>): Promise<Payloads.Map.ByPath<Value>>;
   public async [Method.Map]<Value = StoredValue>(payload: Payloads.Map<StoredValue, Value>): Promise<Payloads.Map<StoredValue, Value>> {
     payload.data = [];
@@ -327,10 +286,16 @@ export class MapProvider<StoredValue = unknown> extends JoshProvider<StoredValue
     if (isMapByPathPayload(payload)) {
       const { path } = payload;
 
-      for (const value of this.cache.values()) {
+      for (const [key, value] of this.cache.entries()) {
         const data = getProperty<Value>(value, path);
 
-        if (data !== PROPERTY_NOT_FOUND) payload.data.push(data);
+        if (data === PROPERTY_NOT_FOUND)
+          return {
+            ...payload,
+            error: this.error({ identifier: CommonIdentifiers.MissingData, method: Method.Map }, { key, path })
+          };
+
+        payload.data.push(data);
       }
     }
 
@@ -339,27 +304,21 @@ export class MapProvider<StoredValue = unknown> extends JoshProvider<StoredValue
 
   public [Method.Math](payload: Payloads.Math): Payloads.Math {
     const { key, path, operator, operand } = payload;
-    let { data } = this.get<number>({ method: Method.Get, key, path });
+    const getPayload = this[Method.Get]<number>({ method: Method.Get, key, path });
 
-    if (data === undefined) {
-      payload.error = this.error({
-        identifier: JoshProvider.CommonIdentifiers.MathMissingData,
-        message: path.length === 0 ? `The data at "${key}" does not exist.` : `The data at "${key}.${path.join('.')}" does not exist.`,
-        method: Method.Math
-      });
+    if (!isPayloadWithData<number>(getPayload))
+      return {
+        ...payload,
+        error: this.error({ identifier: CommonIdentifiers.MissingData, method: Method.Math }, { key, path })
+      };
 
-      return payload;
-    }
+    let { data } = getPayload;
 
-    if (!isNumber(data)) {
-      payload.error = this.error({
-        identifier: JoshProvider.CommonIdentifiers.MathInvalidType,
-        message: path.length === 0 ? `The data at "${key}" must be a number.` : `The data at "${key}.${path.join('.')}" must be a number.`,
-        method: Method.Math
-      });
-
-      return payload;
-    }
+    if (typeof data !== 'number')
+      return {
+        ...payload,
+        error: this.error({ identifier: CommonIdentifiers.InvalidDataType, method: Method.Math }, { key, path, type: 'number' })
+      };
 
     switch (operator) {
       case MathOperator.Addition:
@@ -393,7 +352,7 @@ export class MapProvider<StoredValue = unknown> extends JoshProvider<StoredValue
         break;
     }
 
-    this.set({ method: Method.Set, key, path, value: data });
+    this[Method.Set]({ method: Method.Set, key, path, value: data });
 
     return payload;
   }
@@ -407,9 +366,9 @@ export class MapProvider<StoredValue = unknown> extends JoshProvider<StoredValue
       const { hook } = payload;
 
       for (const [key, value] of this.cache.entries()) {
-        const filterValue = await hook(value);
+        const result = await hook(value);
 
-        if (filterValue) payload.data.truthy[key] = value;
+        if (result) payload.data.truthy[key] = value;
         else payload.data.falsy[key] = value;
       }
     }
@@ -417,21 +376,20 @@ export class MapProvider<StoredValue = unknown> extends JoshProvider<StoredValue
     if (isPartitionByValuePayload(payload)) {
       const { path, value } = payload;
 
-      if (!isPrimitive(value)) {
-        payload.error = this.error({
-          identifier: JoshProvider.CommonIdentifiers.PartitionInvalidValue,
-          message: 'The "value" must be a primitive type.',
-          method: Method.Partition
-        });
-
-        return payload;
-      }
-
       for (const [key, storedValue] of this.cache.entries()) {
         const data = getProperty<StoredValue>(storedValue, path);
 
-        // @ts-expect-error 2367
-        if (value === data) payload.data.truthy[key] = storedValue;
+        if (data === PROPERTY_NOT_FOUND)
+          return {
+            ...payload,
+            error: this.error({ identifier: CommonIdentifiers.MissingData, method: Method.Partition }, { key, path })
+          };
+        if (!isPrimitive(data))
+          return {
+            ...payload,
+            error: this.error({ identifier: CommonIdentifiers.InvalidDataType, method: Method.Partition }, { key, path, type: 'primitive' })
+          };
+        if (data === value) payload.data.truthy[key] = storedValue;
         else payload.data.falsy[key] = storedValue;
       }
     }
@@ -441,31 +399,24 @@ export class MapProvider<StoredValue = unknown> extends JoshProvider<StoredValue
 
   public [Method.Push]<Value = StoredValue>(payload: Payloads.Push<Value>): Payloads.Push<Value> {
     const { key, path, value } = payload;
-    const { data } = this.get({ method: Method.Get, key, path });
+    const getPayload = this[Method.Get]({ method: Method.Get, key, path });
 
-    if (data === undefined) {
-      payload.error = this.error({
-        identifier: JoshProvider.CommonIdentifiers.PushMissingData,
-        message: path.length === 0 ? `The data at "${key}" does not exist.` : `The data at "${key}.${path.join('.')}" does not exist.`,
-        method: Method.Push
-      });
+    if (!isPayloadWithData(getPayload))
+      return {
+        ...payload,
+        error: this.error({ identifier: CommonIdentifiers.MissingData, method: Method.Push }, { key, path })
+      };
 
-      return payload;
-    }
+    const { data } = getPayload;
 
-    if (!Array.isArray(data)) {
-      payload.error = this.error({
-        identifier: JoshProvider.CommonIdentifiers.PushInvalidType,
-        message: path.length === 0 ? `The data at "${key}" must be an array.` : `The data at "${key}.${path.join('.')}" does not exist.`,
-        method: Method.Push
-      });
-
-      return payload;
-    }
+    if (!Array.isArray(data))
+      return {
+        ...payload,
+        error: this.error({ identifier: CommonIdentifiers.InvalidDataType, method: Method.Push }, { key, path, type: 'array' })
+      };
 
     data.push(value);
-
-    this.set({ method: Method.Set, key, path, value: data });
+    this[Method.Set]({ method: Method.Set, key, path, value: data });
 
     return payload;
   }
@@ -473,22 +424,21 @@ export class MapProvider<StoredValue = unknown> extends JoshProvider<StoredValue
   public [Method.Random](payload: Payloads.Random<StoredValue>): Payloads.Random<StoredValue> {
     const { count, duplicates } = payload;
 
-    if (this.cache.size === 0) return payload;
-    if (this.cache.size < count) {
-      payload.error = this.error({
-        identifier: JoshProvider.CommonIdentifiers.RandomInvalidCount,
-        message: `The count of values to be selected must be less than or equal to the number of values in the map.`,
-        method: Method.Random
-      });
-
-      return payload;
-    }
+    if (this.cache.size < count)
+      return {
+        ...payload,
+        error: this.error({ identifier: CommonIdentifiers.InvalidCount, method: Method.Random })
+      };
 
     const data: [string, StoredValue][] = [];
-    const entries = Array.from(this.cache.entries());
 
-    for (let i = 0; i < count; i++)
-      data.push(duplicates ? entries[Math.floor(Math.random() & entries.length)] : this.randomEntriesWithoutDuplicates(data));
+    for (let i = 0; i < count; i++) {
+      if (duplicates) {
+        const entries = Array.from(this.cache.entries());
+
+        data.push(entries[Math.floor(Math.random() * entries.length)]);
+      } else data.push(this.randomEntriesWithoutDuplicates(data));
+    }
 
     payload.data = data.map(([, value]) => value);
 
@@ -498,23 +448,21 @@ export class MapProvider<StoredValue = unknown> extends JoshProvider<StoredValue
   public [Method.RandomKey](payload: Payloads.RandomKey): Payloads.RandomKey {
     const { count, duplicates } = payload;
 
-    if (this.cache.size === 0) return payload;
-    if (this.cache.size < count) {
-      payload.error = this.error({
-        identifier: JoshProvider.CommonIdentifiers.RandomKeyInvalidCount,
-        message: `The count of keys to be selected must be less than or equal to the number of keys in the map.`,
-        method: Method.RandomKey
-      });
-
-      return payload;
-    }
+    if (this.cache.size < count)
+      return {
+        ...payload,
+        error: this.error({ identifier: CommonIdentifiers.InvalidCount, method: Method.RandomKey })
+      };
 
     payload.data = [];
 
-    const keys = Array.from(this.cache.keys());
+    for (let i = 0; i < count; i++) {
+      if (duplicates) {
+        const keys = Array.from(this.cache.keys());
 
-    for (let i = 0; i < count; i++)
-      payload.data.push(duplicates ? keys[Math.floor(Math.random() * keys.length)] : this.randomKeyWithoutDuplicates(payload.data));
+        payload.data.push(keys[Math.floor(Math.random() * keys.length)]);
+      } else payload.data.push(this.randomKeyWithoutDuplicates(payload.data));
+    }
 
     return payload;
   }
@@ -524,58 +472,46 @@ export class MapProvider<StoredValue = unknown> extends JoshProvider<StoredValue
   public async [Method.Remove]<Value = StoredValue>(payload: Payloads.Remove<Value>): Promise<Payloads.Remove<Value>> {
     if (isRemoveByHookPayload(payload)) {
       const { key, path, hook } = payload;
-      const { data } = this.get<unknown[]>({ method: Method.Get, key, path });
+      const getPayload = this[Method.Get]({ method: Method.Get, key, path });
 
-      if (data === undefined) {
-        payload.error = this.error({
-          identifier: JoshProvider.CommonIdentifiers.RemoveMissingData,
-          message: path.length === 0 ? `The data at "${key}" does not exist.` : `The data at "${key}.${path.join('.')}" does not exist.`,
-          method: Method.Remove
-        });
+      if (!isPayloadWithData(getPayload))
+        return {
+          ...payload,
+          error: this.error({ identifier: CommonIdentifiers.MissingData, method: Method.Remove })
+        };
 
-        return payload;
-      }
+      const { data } = getPayload;
 
-      if (!Array.isArray(data)) {
-        payload.error = this.error({
-          identifier: JoshProvider.CommonIdentifiers.RemoveInvalidType,
-          message: path.length === 0 ? `The data at "${key}" must be an array.` : `The data at "${key}.${path.join('.')}" must be an array.`,
-          method: Method.Remove
-        });
+      if (!Array.isArray(data))
+        return {
+          ...payload,
+          error: this.error({ identifier: CommonIdentifiers.InvalidDataType, method: Method.Remove }, { key, path, type: 'array' })
+        };
 
-        return payload;
-      }
+      const filtered = await Promise.all(data.map(hook));
 
-      const filterValues = await Promise.all(data.map(hook));
-
-      this.set({ method: Method.Set, key, path, value: data.filter((_, index) => !filterValues[index]) });
+      this[Method.Set]({ method: Method.Set, key, path, value: data.filter((_, index) => !filtered[index]) });
     }
 
     if (isRemoveByValuePayload(payload)) {
       const { key, path, value } = payload;
-      const { data } = this.get({ method: Method.Get, key, path });
+      const getPayload = this[Method.Get]({ method: Method.Get, key, path });
 
-      if (data === undefined) {
-        payload.error = this.error({
-          identifier: JoshProvider.CommonIdentifiers.RemoveMissingData,
-          message: path.length === 0 ? `The data at "${key}" does not exist.` : `The data at "${key}.${path.join('.')}" does not exist.`,
-          method: Method.Remove
-        });
+      if (!isPayloadWithData(getPayload))
+        return {
+          ...payload,
+          error: this.error({ identifier: CommonIdentifiers.MissingData, method: Method.Remove }, { key, path })
+        };
 
-        return payload;
-      }
+      const { data } = getPayload;
 
-      if (!Array.isArray(data)) {
-        payload.error = this.error({
-          identifier: JoshProvider.CommonIdentifiers.RemoveInvalidType,
-          message: path.length === 0 ? `The data at "${key}" must be an array.` : `The data at "${key}.${path.join('.')}" must be an array.`,
-          method: Method.Remove
-        });
+      if (!Array.isArray(data))
+        return {
+          ...payload,
+          error: this.error({ identifier: CommonIdentifiers.InvalidDataType, method: Method.Remove }, { key, path, type: 'array' })
+        };
 
-        return payload;
-      }
-
-      this.set({ method: Method.Set, key, path, value: data.filter((storedValue) => value !== storedValue) });
+      this[Method.Set]({ method: Method.Set, key, path, value: data.filter((v) => v !== value) });
     }
 
     return payload;
@@ -584,18 +520,13 @@ export class MapProvider<StoredValue = unknown> extends JoshProvider<StoredValue
   public [Method.Set]<Value = StoredValue>(payload: Payloads.Set<Value>): Payloads.Set<Value> {
     const { key, path, value } = payload;
 
-    // @ts-expect-error 2345
-    if (path.length === 0) this.cache.set(key, value);
-    else {
-      const storedValue = this.cache.get(key);
-
-      this.cache.set(key, setProperty(storedValue ?? {}, path, value));
-    }
+    if (path.length === 0) this.cache.set(key, value as unknown as StoredValue);
+    else this.cache.set(key, setProperty<StoredValue>(this.cache.get(key), path, value));
 
     return payload;
   }
 
-  public [Method.SetMany]<Value = StoredValue>(payload: Payloads.SetMany<Value>): Payloads.SetMany<Value> {
+  public [Method.SetMany](payload: Payloads.SetMany): Payloads.SetMany {
     const { entries, overwrite } = payload;
 
     for (const [{ key, path }, value] of entries)
@@ -620,26 +551,37 @@ export class MapProvider<StoredValue = unknown> extends JoshProvider<StoredValue
       const { hook } = payload;
 
       for (const value of this.cache.values()) {
-        const someValue = await hook(value);
+        const result = await hook(value);
 
-        if (!someValue) continue;
+        if (result) {
+          payload.data = true;
 
-        payload.data = true;
-
-        break;
+          break;
+        }
       }
     }
 
     if (isSomeByValuePayload(payload)) {
       const { path, value } = payload;
 
-      for (const storedValue of this.cache.values()) {
+      for (const [key, storedValue] of this.cache.entries()) {
         const data = getProperty(storedValue, path);
 
-        if (value !== data) continue;
-        if (isPrimitive(storedValue) && value === storedValue) continue;
+        if (data === PROPERTY_NOT_FOUND)
+          return {
+            ...payload,
+            error: this.error({ identifier: CommonIdentifiers.MissingData, method: Method.Some }, { key, path })
+          };
+        if (!isPrimitive(data))
+          return {
+            ...payload,
+            error: this.error({ identifier: CommonIdentifiers.InvalidDataType, method: Method.Some }, { key, path, type: 'primitive' })
+          };
+        if (data === value) {
+          payload.data = true;
 
-        payload.data = true;
+          break;
+        }
       }
     }
 
@@ -647,18 +589,23 @@ export class MapProvider<StoredValue = unknown> extends JoshProvider<StoredValue
   }
 
   public async [Method.Update]<Value = StoredValue>(payload: Payloads.Update<StoredValue, Value>): Promise<Payloads.Update<StoredValue, Value>> {
-    const { key, path, hook } = payload;
-    const { data } = this.get({ method: Method.Get, key, path });
+    const { key, hook } = payload;
 
-    if (data === undefined) return payload;
+    if (!this.cache.has(key))
+      return {
+        ...payload,
+        error: this.error({ identifier: CommonIdentifiers.MissingData, method: Method.Update }, { key })
+      };
 
-    this.set({ method: Method.Set, key, path, value: await hook(data) });
+    const data = this.cache.get(key)!;
+
+    this[Method.Set]({ method: Method.Set, key, path: [], value: await hook(data) });
 
     return payload;
   }
 
   public [Method.Values](payload: Payloads.Values<StoredValue>): Payloads.Values<StoredValue> {
-    Reflect.set(payload, 'data', Array.from(this.cache.values()));
+    payload.data = Array.from(this.cache.values());
 
     return payload;
   }

--- a/src/lib/structures/default-provider/MapProvider.ts
+++ b/src/lib/structures/default-provider/MapProvider.ts
@@ -470,17 +470,19 @@ export class MapProvider<StoredValue = unknown> extends JoshProvider<StoredValue
   public async [Method.Remove]<Value = StoredValue>(payload: Payloads.Remove.ByHook<Value>): Promise<Payloads.Remove.ByHook<Value>>;
   public async [Method.Remove](payload: Payloads.Remove.ByValue): Promise<Payloads.Remove.ByValue>;
   public async [Method.Remove]<Value = StoredValue>(payload: Payloads.Remove<Value>): Promise<Payloads.Remove<Value>> {
+    const { key, path } = payload;
+    const getPayload = this[Method.Get]({ method: Method.Get, key, path });
+
+    if (!isPayloadWithData(getPayload))
+      return {
+        ...payload,
+        error: this.error({ identifier: CommonIdentifiers.MissingData, method: Method.Remove })
+      };
+
+    const { data } = getPayload;
+
     if (isRemoveByHookPayload(payload)) {
-      const { key, path, hook } = payload;
-      const getPayload = this[Method.Get]({ method: Method.Get, key, path });
-
-      if (!isPayloadWithData(getPayload))
-        return {
-          ...payload,
-          error: this.error({ identifier: CommonIdentifiers.MissingData, method: Method.Remove })
-        };
-
-      const { data } = getPayload;
+      const { hook } = payload;
 
       if (!Array.isArray(data))
         return {
@@ -494,16 +496,7 @@ export class MapProvider<StoredValue = unknown> extends JoshProvider<StoredValue
     }
 
     if (isRemoveByValuePayload(payload)) {
-      const { key, path, value } = payload;
-      const getPayload = this[Method.Get]({ method: Method.Get, key, path });
-
-      if (!isPayloadWithData(getPayload))
-        return {
-          ...payload,
-          error: this.error({ identifier: CommonIdentifiers.MissingData, method: Method.Remove }, { key, path })
-        };
-
-      const { data } = getPayload;
+      const { value } = payload;
 
       if (!Array.isArray(data))
         return {

--- a/src/lib/types/CommonIdentifiers.ts
+++ b/src/lib/types/CommonIdentifiers.ts
@@ -1,0 +1,11 @@
+export enum CommonIdentifiers {
+  InvalidCount = 'invalidCount',
+
+  InvalidDataType = 'invalidDataType',
+
+  InvalidValueType = 'invalidValueType',
+
+  MissingData = 'missingData',
+
+  MissingValue = 'missingValue'
+}

--- a/src/lib/types/Payloads.ts
+++ b/src/lib/types/Payloads.ts
@@ -768,7 +768,7 @@ export namespace Payloads {
    * @see {@link Payload}
    * @see {@link Payload.Data}
    */
-  export interface SetMany<Value> extends Payload {
+  export interface SetMany extends Payload {
     /**
      * The method this payload is for.
      * @since 2.0.0
@@ -785,7 +785,7 @@ export namespace Payloads {
      * The entries to set.
      * @since 2.0.0
      */
-    entries: [Payload.KeyPath, Value][];
+    entries: [Payload.KeyPath, unknown][];
   }
 
   /**
@@ -879,12 +879,18 @@ export namespace Payloads {
    * @see {@link Payload.KeyPath}
    * @see {@link Payload.Data}
    */
-  export interface Update<Value, ReturnValue> extends Payload, Payload.KeyPath {
+  export interface Update<Value, ReturnValue> extends Payload {
     /**
      * The method this payload is for.
      * @since 2.0.0
      */
     method: Method.Update;
+
+    /**
+     * The key to the value to update.
+     * @since 2.0.0
+     */
+    key: string;
 
     /**
      * The hook to update stored value.

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -1,4 +1,5 @@
 export * from './BuiltInMiddleware';
+export * from './CommonIdentifiers';
 export * from './KeyPath';
 export * from './MathOperator';
 export * from './Method';

--- a/tests/lib/structures/default-provider/MapProvider.test.ts
+++ b/tests/lib/structures/default-provider/MapProvider.test.ts
@@ -30,7 +30,6 @@ describe('MapProvider', () => {
         expect(trigger).toBeUndefined();
         expect(error).toBeUndefined();
         expect(data).toBe('1');
-
         expect(provider['autoKeyCount']).toBe(1);
       });
     });


### PR DESCRIPTION
This PR includes a workspace wide review. Many changes were made.

# Changes

- Add `resolveCommonIdentifiers()` function.
- Change `Josh#error()` and `JoshProvider#error()` to utilize `resolveCommonIdentifiers()`
- Move `Josh#isPayloadWithData()` method to a separate function.
- Add missing checks.
- Remove unused checks.
- Rename `Josh#getKeyPath()` to `Josh#resolveKeyPath()`
- Rename `Josh#getPath()` to `Josh#resolvePath()`
- Add `Josh#resolveIdentifier()`
- Add more detailed documentation to `JoshProvider` to help ensure all providers behave the same.
- Move `Josh.CommonIdentifiers` enum to a separate file.
- Remove `Value` generic type from `Payloads.SetMany` since this only added issues when actually using the method forcing all values to be the same.
- Remove `path` property from `Payloads.Update`
- Rewrite `MapProvider`
- [ ] Rewrite `MapProvider` tests
- [ ] Add proper tests for `Josh`
- [ ] Refactor middleware context data and how it's handled.