### PR TITLE
feat(payloads): add/remove properties

### DIFF
--- a/src/lib/structures/Josh.ts
+++ b/src/lib/structures/Josh.ts
@@ -1511,7 +1511,7 @@ export class Josh<StoredValue = unknown> {
 
   /**
    * Update a stored value using a hook function.
-   * @param keyPath The key and/or path to the stored value for updating.
+   * @param key The key to the stored value for updating.
    * @param hook The hook to update the stored value.
    * @returns The updated value or null.
    *
@@ -1522,9 +1522,8 @@ export class Josh<StoredValue = unknown> {
    * await josh.update('key', (value) => value.toUpperCase()); // 'VALUE'
    * ```
    */
-  public async update<Value = StoredValue>(keyPath: KeyPath, hook: Payload.Hook<StoredValue, Value>): Promise<this> {
-    const [key, path] = this.getKeyPath(keyPath);
-    let payload: Payloads.Update<StoredValue, Value> = { method: Method.Update, trigger: Trigger.PreProvider, key, path, hook };
+  public async update<Value = StoredValue>(key: string, hook: Payload.Hook<StoredValue, Value>): Promise<this> {
+    let payload: Payloads.Update<StoredValue, Value> = { method: Method.Update, trigger: Trigger.PreProvider, key, hook };
 
     for (const middleware of this.middlewares.array()) await middleware.run(payload);
     for (const middleware of this.middlewares.getPreMiddlewares(Method.Update)) payload = await middleware[Method.Update](payload);

--- a/src/lib/structures/Josh.ts
+++ b/src/lib/structures/Josh.ts
@@ -1378,8 +1378,8 @@ export class Josh<StoredValue = unknown> {
     return this;
   }
 
-  public async setMany<Value = StoredValue>(entries: [KeyPath, Value][], overwrite = true): Promise<this> {
-    let payload: Payloads.SetMany<Value> = {
+  public async setMany(entries: [KeyPath, unknown][], overwrite = true): Promise<this> {
+    let payload: Payloads.SetMany = {
       method: Method.SetMany,
       trigger: Trigger.PreProvider,
       entries: entries.map(([keyPath, value]) => {

--- a/src/lib/structures/JoshProvider.ts
+++ b/src/lib/structures/JoshProvider.ts
@@ -282,7 +282,7 @@ export abstract class JoshProvider<StoredValue = unknown> {
    * @param payload The payload sent by this provider's {@link Josh} instance.
    * @returns The payload (modified), originally sent by this provider's {@link Josh} instance.
    */
-  public abstract [Method.SetMany]<Value = StoredValue>(payload: Payloads.SetMany<Value>): Awaitable<Payloads.SetMany<Value>>;
+  public abstract [Method.SetMany](payload: Payloads.SetMany): Awaitable<Payloads.SetMany>;
 
   /**
    * @since 2.0.0

--- a/src/lib/structures/Middleware.ts
+++ b/src/lib/structures/Middleware.ts
@@ -188,7 +188,7 @@ export class Middleware<StoredValue = unknown> {
     return payload;
   }
 
-  public [Method.SetMany]<Value = StoredValue>(payload: Payloads.SetMany<Value>): Awaitable<Payloads.SetMany<Value>> {
+  public [Method.SetMany](payload: Payloads.SetMany): Awaitable<Payloads.SetMany> {
     return payload;
   }
 

--- a/src/lib/structures/default-provider/MapProvider.ts
+++ b/src/lib/structures/default-provider/MapProvider.ts
@@ -647,12 +647,12 @@ export class MapProvider<StoredValue = unknown> extends JoshProvider<StoredValue
   }
 
   public async [Method.Update]<Value = StoredValue>(payload: Payloads.Update<StoredValue, Value>): Promise<Payloads.Update<StoredValue, Value>> {
-    const { key, path, hook } = payload;
-    const { data } = this.get({ method: Method.Get, key, path });
+    const { key, hook } = payload;
+    const data = this.cache.get(key);
 
     if (data === undefined) return payload;
 
-    this.set({ method: Method.Set, key, path, value: await hook(data) });
+    this.cache.set(key, (await hook(data)) as unknown as StoredValue);
 
     return payload;
   }

--- a/src/lib/structures/default-provider/MapProvider.ts
+++ b/src/lib/structures/default-provider/MapProvider.ts
@@ -595,7 +595,7 @@ export class MapProvider<StoredValue = unknown> extends JoshProvider<StoredValue
     return payload;
   }
 
-  public [Method.SetMany]<Value = StoredValue>(payload: Payloads.SetMany<Value>): Payloads.SetMany<Value> {
+  public [Method.SetMany](payload: Payloads.SetMany): Payloads.SetMany {
     const { entries, overwrite } = payload;
 
     for (const [{ key, path }, value] of entries)

--- a/src/lib/types/Payloads.ts
+++ b/src/lib/types/Payloads.ts
@@ -768,7 +768,7 @@ export namespace Payloads {
    * @see {@link Payload}
    * @see {@link Payload.Data}
    */
-  export interface SetMany<Value> extends Payload {
+  export interface SetMany extends Payload {
     /**
      * The method this payload is for.
      * @since 2.0.0
@@ -785,7 +785,7 @@ export namespace Payloads {
      * The entries to set.
      * @since 2.0.0
      */
-    entries: [Payload.KeyPath, Value][];
+    entries: [Payload.KeyPath, unknown][];
   }
 
   /**

--- a/src/lib/types/Payloads.ts
+++ b/src/lib/types/Payloads.ts
@@ -879,12 +879,18 @@ export namespace Payloads {
    * @see {@link Payload.KeyPath}
    * @see {@link Payload.Data}
    */
-  export interface Update<Value, ReturnValue> extends Payload, Payload.KeyPath {
+  export interface Update<Value, ReturnValue> extends Payload {
     /**
      * The method this payload is for.
      * @since 2.0.0
      */
     method: Method.Update;
+
+    /**
+     * The key to the value to update.
+     * @since 2.0.0
+     */
+    key: string;
 
     /**
      * The hook to update stored value.

--- a/src/middlewares/CoreAutoEnsure.ts
+++ b/src/middlewares/CoreAutoEnsure.ts
@@ -36,6 +36,8 @@ export class CoreAutoEnsure<StoredValue = unknown> extends Middleware<StoredValu
   }
 
   public async [Method.GetMany](payload: Payloads.GetMany<StoredValue>): Promise<Payloads.GetMany<StoredValue>> {
+    payload.data = {};
+
     if (Object.keys(payload.data).length !== 0) return payload;
     if (!this.context) return payload;
 
@@ -109,12 +111,12 @@ export class CoreAutoEnsure<StoredValue = unknown> extends Middleware<StoredValu
     return payload;
   }
 
-  public async [Method.SetMany]<Value>(payload: Payloads.SetMany<Value>): Promise<Payloads.SetMany<Value>> {
+  public async [Method.SetMany](payload: Payloads.SetMany): Promise<Payloads.SetMany> {
     if (!this.context) return payload;
 
     const { defaultValue } = this.context;
 
-    for (const [{ key }] of payload.data) await this.provider.ensure({ method: Method.Ensure, key, data: defaultValue, defaultValue });
+    for (const [{ key }] of payload.entries) await this.provider.ensure({ method: Method.Ensure, key, data: defaultValue, defaultValue });
 
     return payload;
   }

--- a/tests/lib/structures/default-provider/MapProvider.test.ts
+++ b/tests/lib/structures/default-provider/MapProvider.test.ts
@@ -1617,51 +1617,48 @@ describe('MapProvider', () => {
 
     describe('with update method', () => {
       test('GIVEN provider w/o data THEN returns payload w/o data', async () => {
-        const payload = await provider.update({ method: Method.Update, key: 'test:update', path: [], hook: (value) => value });
+        const payload = await provider.update({ method: Method.Update, key: 'test:update', hook: (value) => value });
 
         expect(typeof payload).toBe('object');
 
-        const { method, trigger, error, key, path, hook } = payload;
+        const { method, trigger, error, key, hook } = payload;
 
         expect(method).toBe(Method.Update);
         expect(trigger).toBeUndefined();
         expect(error).toBeUndefined();
         expect(key).toBe('test:update');
-        expect(path).toEqual([]);
         expect(typeof hook).toBe('function');
       });
 
       test('GIVEN provider w/ data at key THEN returns payload w/ data AND updates value at key', async () => {
         provider.set({ method: Method.Set, key: 'test:update', path: [], value: 'value' });
 
-        const payload = await provider.update({ method: Method.Update, key: 'test:update', path: [], hook: (value) => value });
+        const payload = await provider.update({ method: Method.Update, key: 'test:update', hook: (value) => value });
 
         expect(typeof payload).toBe('object');
 
-        const { method, trigger, error, key, path, hook } = payload;
+        const { method, trigger, error, key, hook } = payload;
 
         expect(method).toBe(Method.Update);
         expect(trigger).toBeUndefined();
         expect(error).toBeUndefined();
         expect(key).toBe('test:update');
-        expect(path).toEqual([]);
         expect(typeof hook).toBe('function');
       });
 
       test('GIVEN provider w/ data at path THEN returns payload w/ data AND updates value at path', async () => {
         provider.set({ method: Method.Set, key: 'test:update', path: ['path'], value: 'value' });
 
-        const payload = await provider.update({ method: Method.Update, key: 'test:update', path: ['path'], hook: (value) => value });
+        const payload = await provider.update({ method: Method.Update, key: 'test:update', hook: (value) => value });
 
         expect(typeof payload).toBe('object');
 
-        const { method, trigger, error, key, path, hook } = payload;
+        const { method, trigger, error, key, hook } = payload;
 
         expect(method).toBe(Method.Update);
         expect(trigger).toBeUndefined();
         expect(error).toBeUndefined();
         expect(key).toBe('test:update');
-        expect(path).toEqual(['path']);
         expect(typeof hook).toBe('function');
       });
     });


### PR DESCRIPTION
This PR makes some changes to `Payloads.SetMany` and `Payloads.Update` for better simplicity.

# Changes

- Remove type generic from `Payloads.SetMany`, this fixes some issues for end-users setting different values per-key.
- Remove `path` property from `Payloads.Update`, this removes extra complexity from this method.
