### PR TITLE
feat: refactor key-path system

### DIFF
--- a/src/lib/structures/Josh.ts
+++ b/src/lib/structures/Josh.ts
@@ -233,38 +233,20 @@ export class Josh<StoredValue = unknown> {
    *
    * @example
    * ```javascript
-   * await josh.set('key', 1);
+   * await josh.set('key', 1, 'path');
    *
-   * await josh.inc({ key: 'key' });
+   * await josh.inc('key', 'path');
    *
-   * await josh.get('key'); // 0
+   * await josh.get('key', 'path); // 0
    * ```
    *
    * @example
    * ```javascript
-   * await josh.set('key.path', 1);
+   * await josh.set('key', 1, 'path');
    *
-   * await josh.inc('key.path');
+   * await josh.inc('key', ['path']);
    *
-   * await josh.get('key.path'); // 0
-   * ```
-   *
-   * @example
-   * ```javascript
-   * await josh.set('key.path', 1);
-   *
-   * await josh.inc({ key: 'key', path: 'path' });
-   *
-   * await josh.get('key.path'); // 0
-   * ```
-   *
-   * @example
-   * ```javascript
-   * await josh.set('key.path', 1);
-   *
-   * await josh.inc({ key: 'key', path: ['path'] });
-   *
-   * await josh.get('key.path'); // 0
+   * await josh.get('key', 'path'); // 0
    * ```
    */
   public async dec(key: string, path: Path = []): Promise<this> {
@@ -304,18 +286,9 @@ export class Josh<StoredValue = unknown> {
    *
    * @example
    * ```javascript
-   * await josh.set('key', 'value');
-   *
-   * await josh.delete({ key: 'key' });
-   *
-   * await josh.get('key'); // null
-   * ```
-   *
-   * @example
-   * ```javascript
    * await josh.set('key', { path: 'value' });
    *
-   * await josh.delete('key.path');
+   * await josh.delete('key'`, 'path');
    *
    * await josh.get('key'); // {}
    * ```
@@ -324,16 +297,7 @@ export class Josh<StoredValue = unknown> {
    * ```javascript
    * await josh.set('key', { path: 'value' });
    *
-   * await josh.delete({ key: 'key', path: 'path' });
-   *
-   * await josh.get('key'); // {}
-   * ```
-   *
-   * @example
-   * ```javascript
-   * await josh.set('key', { path: 'value' });
-   *
-   * await josh.delete({ key: 'key', path: ['path'] });
+   * await josh.delete('key', ['path']);
    *
    * await josh.get('key'); // {}
    * ```
@@ -715,16 +679,14 @@ export class Josh<StoredValue = unknown> {
    * await josh.set('key', { path: 'value' });
    *
    * await josh.get('key'); // { path: 'value' }
-   * await josh.get({ key: 'key' }); // { path: 'value' }
    * ```
    *
    * @example
    * ```javascript
    * await josh.set('key', { path: 'value' });
    *
-   * await josh.get('key.path'); // 'value'
-   * await josh.get({ key: 'key', path: 'path' }); // 'value'
-   * await josh.get({ key: 'key', path: ['path'] }); //'value'
+   * await josh.get('key', 'path'); // 'value'
+   * await josh.get('key', ['path']); // 'value'
    * ```
    */
   public async get<Value = StoredValue>(key: string, path: Path = []): Promise<Value | null> {
@@ -839,25 +801,21 @@ export class Josh<StoredValue = unknown> {
    * @example
    * ```javascript
    * await josh.has('key'); // false
-   * await josh.has({ key: 'key' }) // false
    *
    * await josh.set('key', 'value');
    *
    * await josh.has('key'); // true
-   * await josh.has({ key: 'key' }) // true
    * ```
    *
    * @example
    * ```javascript
-   * await josh.has('key.path'); // false
-   * await josh.has({ key: 'key', path: 'path' }); // false
-   * await josh.has({ key: 'key', path: ['path'] }) // false
+   * await josh.has('key', 'path'); // false
+   * await josh.has('key', ['path']); // false
    *
    * await josh.set('key', { path: 'value' });
    *
-   * await josh.has('key.path'); // true
-   * await josh.has({ key: 'key', path: 'path' }); // true
-   * await josh.has({ key: 'key', path: ['path'] }) // true
+   * await josh.has('key', 'path'); // true
+   * await josh.has('key', ['path']); // true
    * ```
    */
   public async has(key: string, path: Path = []): Promise<boolean> {
@@ -900,38 +858,20 @@ export class Josh<StoredValue = unknown> {
    *
    * @example
    * ```javascript
-   * await josh.set('key', 0);
+   * await josh.set('key', 0, 'path');
    *
-   * await josh.inc({ key: 'key' });
+   * await josh.inc('key', 'path');
    *
-   * await josh.get('key'); // 1
+   * await josh.get('key', 'path'); // 1
    * ```
    *
    * @example
    * ```javascript
-   * await josh.set('key.path', 0);
+   * await josh.set('key', 0, 'path');
    *
-   * await josh.inc('key.path');
+   * await josh.inc('key', ['path']);
    *
-   * await josh.get('key.path'); // 1
-   * ```
-   *
-   * @example
-   * ```javascript
-   * await josh.set('key.path', 0);
-   *
-   * await josh.inc({ key: 'key', path: 'path' });
-   *
-   * await josh.get('key.path'); // 1
-   * ```
-   *
-   * @example
-   * ```javascript
-   * await josh.set('key.path', 0);
-   *
-   * await josh.inc({ key: 'key', path: ['path'] });
-   *
-   * await josh.get('key.path'); // 1
+   * await josh.get('key', 'path); // 1
    * ```
    */
   public async inc(key: string, path: Path = []): Promise<this> {
@@ -1203,7 +1143,6 @@ export class Josh<StoredValue = unknown> {
    * await josh.set('key', []);
    *
    * await josh.push('key', 'value');
-   * await josh.push({ key: 'key' }, 'value');
    *
    * await josh.get('key'); // ['value']
    * ```
@@ -1212,11 +1151,10 @@ export class Josh<StoredValue = unknown> {
    * ```javascript
    * await josh.set('key', { path: [] });
    *
-   * await josh.push('key.path', 'value');
-   * await josh.push({ key: 'key', path: 'path' }, 'value');
-   * await josh.push({ key: 'key', path: ['path'] }, 'value');
+   * await josh.push('key', 'value', 'path');
+   * await josh.push('key', 'value', ['path']);
    *
-   * await josh.get('key.path'); // ['value']
+   * await josh.get('key', 'path'); // ['value']
    * ```
    */
   public async push<Value = StoredValue>(key: string, value: Value, path: Path = []): Promise<this> {
@@ -1313,11 +1251,11 @@ export class Josh<StoredValue = unknown> {
    *
    * @example
    * ```javascript
-   * await provider.set('key', ['value']);
+   * await josh.set('key', ['value']);
    *
-   * await provider.remove('key', 'value');
+   * await josh.remove('key', 'value');
    *
-   * await provider.get('key'); // []
+   * await josh.get('key'); // []
    * ```
    */
   public async remove(key: string, value: Primitive, path?: Path): Promise<this>;
@@ -1331,11 +1269,11 @@ export class Josh<StoredValue = unknown> {
    *
    * @example
    * ```javascript
-   * await provider.set('key', ['value']);
+   * await josh.set('key', ['value']);
    *
-   * await provider.remove('key', (value) => value === 'value');
+   * await josh.remove('key', (value) => value === 'value');
    *
-   * await provider.get('key'); // []
+   * await josh.get('key'); // []
    * ```
    */
   public async remove<Value = StoredValue>(key: string, hook: Payload.Hook<Value>, path?: Path): Promise<this>;
@@ -1382,14 +1320,12 @@ export class Josh<StoredValue = unknown> {
    * @example
    * ```javascript
    * await josh.set('key', { path: 'value' });
-   * await josh.set({ key: 'key' });
    * ```
    *
    * @example
    * ```javascript
-   * await josh.set('key.path');
-   * await josh.set({ key: 'key', path: 'path' });
-   * await josh.set({ key: 'key', path: ['path'] });
+   * await josh.set('key', 'value', 'path');
+   * await josh.set('key', 'value', ['path']);
    * ```
    */
   public async set<Value = StoredValue>(key: string, value: Value, path: Path = []): Promise<this> {
@@ -1475,14 +1411,14 @@ export class Josh<StoredValue = unknown> {
    *
    * @example
    * ```javascript
-   * await provider.some('path', 'value'); // false
+   * await josh.some('path', 'value'); // false
    * ```
    *
    * @example
    * ```javascript
-   * await provider.set('key.path', 'value');
+   * await josh.set('key', 'value', 'path');
    *
-   * await provider.some('path', 'value'); // true
+   * await josh.some('path', 'value'); // true
    * ```
    *
    */
@@ -1495,14 +1431,14 @@ export class Josh<StoredValue = unknown> {
    *
    * @example
    * ```javascript
-   * await provider.some((value) => value === 'value'); // false
+   * await josh.some((value) => value === 'value'); // false
    * ```
    *
    * @example
    * ```javascript
-   * await provider.set('key.path', 'value');
+   * await josh.set('key', 'value', 'path');
    *
-   * await provider.some('path', 'value'); // true
+   * await josh.some('path', 'value'); // true
    * ```
    */
   public async some(hook: Payload.Hook<StoredValue>): Promise<boolean>;

--- a/src/lib/structures/Josh.ts
+++ b/src/lib/structures/Josh.ts
@@ -1710,7 +1710,7 @@ export class Josh<StoredValue = unknown> {
   }
 
   private resolvePath(path: Path): string[] {
-    return Array.isArray(path) ? path : path.replace(/\[/g, '').replace(/\]/g, '').split('.').filter(Boolean);
+    return Array.isArray(path) ? path : path.replace(/\[/g, '.').replace(/\]/g, '').split('.').filter(Boolean);
   }
 
   private get providerFailedError(): JoshError {

--- a/src/lib/structures/Josh.ts
+++ b/src/lib/structures/Josh.ts
@@ -218,7 +218,8 @@ export class Josh<StoredValue = unknown> {
   /**
    * Decrement an integer by `1`.
    * @since 2.0.0
-   * @param keyPath The key/path to the integer for decrementing.
+   * @param key The key to the integer for decrementing.
+   * @param path The path to the integer for decrementing.
    * @returns The {@link Josh} instance.
    *
    * @example
@@ -266,8 +267,9 @@ export class Josh<StoredValue = unknown> {
    * await josh.get('key.path'); // 0
    * ```
    */
-  public async dec(keyPath: KeyPath): Promise<this> {
-    const [key, path] = this.resolveKeyPath(keyPath);
+  public async dec(key: string, path: Path = []): Promise<this> {
+    path = this.resolvePath(path);
+
     let payload: Payloads.Dec = { method: Method.Dec, trigger: Trigger.PreProvider, key, path };
 
     for (const middleware of this.middlewares.array()) await middleware.run(payload);
@@ -287,7 +289,8 @@ export class Josh<StoredValue = unknown> {
   /**
    * Deletes a key or path in a key value.
    * @since 2.0.0
-   * @param keyPath The key/path to delete from.
+   * @param key The key to delete from.
+   * @param path The path to delete from.
    * @returns The {@link Josh} instance.
    *
    * @example
@@ -335,8 +338,9 @@ export class Josh<StoredValue = unknown> {
    * await josh.get('key'); // {}
    * ```
    */
-  public async delete(keyPath: KeyPath): Promise<this> {
-    const [key, path] = this.resolveKeyPath(keyPath);
+  public async delete(key: string, path: Path = []): Promise<this> {
+    path = this.resolvePath(path);
+
     let payload: Payloads.Delete = { method: Method.Delete, trigger: Trigger.PreProvider, key, path };
 
     for (const middleware of this.middlewares.array()) await middleware.run(payload);
@@ -681,7 +685,8 @@ export class Josh<StoredValue = unknown> {
   /**
    * Get a value using a key and/or path.
    * @since 2.0.0
-   * @param keyPath A key and/or path at which a value is.
+   * @param key A key at which a value is.
+   * @param path A path to the value.
    * @returns The value gotten or null.
    *
    * @example
@@ -701,8 +706,9 @@ export class Josh<StoredValue = unknown> {
    * await josh.get({ key: 'key', path: ['path'] }); //'value'
    * ```
    */
-  public async get<Value = StoredValue>(keyPath: KeyPath): Promise<Value | null> {
-    const [key, path] = this.resolveKeyPath(keyPath);
+  public async get<Value = StoredValue>(key: string, path: Path = []): Promise<Value | null> {
+    path = this.resolvePath(path);
+
     let payload: Payloads.Get<Value> = { method: Method.Get, trigger: Trigger.PreProvider, key, path };
 
     for (const middleware of this.middlewares.array()) await middleware.run(payload);
@@ -805,7 +811,8 @@ export class Josh<StoredValue = unknown> {
   /**
    * Check if a key and/or path exists.
    * @since 2.0.0
-   * @param keyPath A key and/or path to the value to check for.
+   * @param key A key to the value to check for.
+   * @param path A path to the value to check for.
    * @returns Whether the value exists.
    *
    * @example
@@ -832,8 +839,9 @@ export class Josh<StoredValue = unknown> {
    * await josh.has({ key: 'key', path: ['path'] }) // true
    * ```
    */
-  public async has(keyPath: KeyPath): Promise<boolean> {
-    const [key, path] = this.resolveKeyPath(keyPath);
+  public async has(key: string, path: Path = []): Promise<boolean> {
+    path = this.resolvePath(path);
+
     let payload: Payloads.Has = { method: Method.Has, trigger: Trigger.PreProvider, key, path };
 
     for (const middleware of this.middlewares.array()) await middleware.run(payload);
@@ -856,7 +864,8 @@ export class Josh<StoredValue = unknown> {
   /**
    * Increment an integer by `1`.
    * @since 2.0.0
-   * @param keyPath The key and/or path to an integer value for incrementing.
+   * @param key The key to an integer value for incrementing.
+   * @param path The path to an integer value for incrementing.
    * @returns The {@link Josh} instance.
    *
    * @example
@@ -904,8 +913,9 @@ export class Josh<StoredValue = unknown> {
    * await josh.get('key.path'); // 1
    * ```
    */
-  public async inc(keyPath: KeyPath): Promise<this> {
-    const [key, path] = this.resolveKeyPath(keyPath);
+  public async inc(key: string, path: Path = []): Promise<this> {
+    path = this.resolvePath(path);
+
     let payload: Payloads.Inc = { method: Method.Inc, trigger: Trigger.PreProvider, key, path };
 
     for (const middleware of this.middlewares.array()) await middleware.run(payload);
@@ -1011,9 +1021,10 @@ export class Josh<StoredValue = unknown> {
   /**
    * Executes math operations on a value with an operand at a specified key and/or path.
    * @since 2.0.0
-   * @param keyPath The key and/or path the value is at.
+   * @param key The key the value is at.
    * @param operator The operator that will be used on the operand and value.
    * @param operand The operand to apply to the value.
+   * @param path The path to the value.
    * @returns The {@link Josh} instance.
    *
    * @example
@@ -1052,8 +1063,9 @@ export class Josh<StoredValue = unknown> {
    * await josh.get('key'); 1
    * ```
    */
-  public async math(keyPath: KeyPath, operator: MathOperator, operand: number): Promise<this> {
-    const [key, path] = this.resolveKeyPath(keyPath);
+  public async math(key: string, operator: MathOperator, operand: number, path: Path = []): Promise<this> {
+    path = this.resolvePath(path);
+
     let payload: Payloads.Math = { method: Method.Math, trigger: Trigger.PreProvider, key, path, operator, operand };
 
     for (const middleware of this.middlewares.array()) await middleware.run(payload);
@@ -1160,8 +1172,9 @@ export class Josh<StoredValue = unknown> {
   /**
    * Push a value to an array.
    * @since 2.0.0
-   * @param keyPath A key and/or path to the array.
+   * @param key A key to the array.
    * @param value The value to push.
+   * @param path A path to the array.
    * @returns The {@link Josh} instance.
    *
    * @example
@@ -1185,8 +1198,9 @@ export class Josh<StoredValue = unknown> {
    * await josh.get('key.path'); // ['value']
    * ```
    */
-  public async push<Value = StoredValue>(keyPath: KeyPath, value: Value): Promise<this> {
-    const [key, path] = this.resolveKeyPath(keyPath);
+  public async push<Value = StoredValue>(key: string, value: Value, path: Path = []): Promise<this> {
+    path = this.resolvePath(path);
+
     let payload: Payloads.Push<Value> = { method: Method.Push, trigger: Trigger.PreProvider, key, path, value };
 
     for (const middleware of this.middlewares.array()) await middleware.run(payload);
@@ -1272,7 +1286,7 @@ export class Josh<StoredValue = unknown> {
   /**
    * Removes an element from an array at a key and/or path that matches the given value.
    * @since 2.0.0
-   * @param keyPath The key and/or path to the array to remove an element.
+   * @param key The key and/or path to the array to remove an element.
    * @param value The value to match to an element in the array.
    * @returns The {@link Josh} instance.
    *
@@ -1285,12 +1299,12 @@ export class Josh<StoredValue = unknown> {
    * await provider.get('key'); // []
    * ```
    */
-  public async remove(keyPath: KeyPath, value: Primitive): Promise<this>;
+  public async remove(key: string, value: Primitive, path?: Path): Promise<this>;
 
   /**
    * Removes an element from an array at a key and/or path that are validated by a hook function.
    * @since 2.0.0
-   * @param keyPath The key and/or path to the array to remove an element.
+   * @param key The key and/or path to the array to remove an element.
    * @param hook The hook function to validate elements in the array.
    * @returns The {@link Josh} instance.
    *
@@ -1303,9 +1317,9 @@ export class Josh<StoredValue = unknown> {
    * await provider.get('key'); // []
    * ```
    */
-  public async remove<Value = StoredValue>(keyPath: KeyPath, hook: Payload.Hook<Value>): Promise<this>;
-  public async remove<Value = StoredValue>(keyPath: KeyPath, valueOrHook: Primitive | Payload.Hook<Value>): Promise<this> {
-    const [key, path] = this.resolveKeyPath(keyPath);
+  public async remove<Value = StoredValue>(key: string, hook: Payload.Hook<Value>, path?: Path): Promise<this>;
+  public async remove<Value = StoredValue>(key: string, valueOrHook: Primitive | Payload.Hook<Value>, path: Path = []): Promise<this> {
+    path = this.resolvePath(path);
 
     if (!isFunction(valueOrHook)) {
       if (!isPrimitive(valueOrHook)) throw this.error(CommonIdentifiers.InvalidValueType, { type: 'primitive' });
@@ -1339,8 +1353,9 @@ export class Josh<StoredValue = unknown> {
   /**
    * Sets a value using a key and/or path.
    * @since 2.0.0
-   * @param keyPath The key and/or path to set the value to.
+   * @param key The key to set the value to.
    * @param value The value to set at the key and/or path.
+   * @returns The {@link Josh} instance.
    * @returns The {@link Josh} instance.
    *
    * @example
@@ -1356,8 +1371,9 @@ export class Josh<StoredValue = unknown> {
    * await josh.set({ key: 'key', path: ['path'] });
    * ```
    */
-  public async set<Value = StoredValue>(keyPath: KeyPath, value: Value): Promise<this> {
-    const [key, path] = this.resolveKeyPath(keyPath);
+  public async set<Value = StoredValue>(key: string, value: Value, path: Path = []): Promise<this> {
+    path = this.resolvePath(path);
+
     let payload: Payloads.Set<Value> = { method: Method.Set, trigger: Trigger.PreProvider, key, path, value };
 
     for (const middleware of this.middlewares.array()) await middleware.run(payload);
@@ -1673,7 +1689,7 @@ export class Josh<StoredValue = unknown> {
   }
 
   private resolvePath(path: Path): string[] {
-    return typeof path === 'string' ? path.split('.') : path;
+    return Array.isArray(path) ? path : path.replace(/\[/g, '').replace(/\]/g, '').split('.').filter(Boolean);
   }
 
   private get providerFailedError(): JoshError {

--- a/tests/lib/structures/Josh.test.ts
+++ b/tests/lib/structures/Josh.test.ts
@@ -10,4 +10,15 @@ describe('Josh', () => {
       expect(typeof Josh.prototype).toBe('object');
     });
   });
+
+  describe('methods runs', () => {
+    const josh = new Josh({ name: 'test:name' });
+
+    test('resolvePath', () => {
+      expect(josh['resolvePath']('test.path')).toEqual(['test', 'path']);
+      expect(josh['resolvePath']('test.path.to.file')).toEqual(['test', 'path', 'to', 'file']);
+      expect(josh['resolvePath']('test.path.to[0].index')).toEqual(['test', 'path', 'to', '0', 'index']);
+      expect(josh['resolvePath']('test[0].path.to[1].index')).toEqual(['test', '0', 'path', 'to', '1', 'index']);
+    });
+  });
 });


### PR DESCRIPTION
This PR refactors the key-path system to better mimic Enmap while also allowing for array paths.

# Changes

- `Josh#dec(keyPath: KeyPath)` --> `(key: string, path?: Path)`
- `Josh#delete(keyPath: KeyPath)` --> `(key: string, path?: Path)`
- `Josh#get(keyPath: KeyPath)` --> `(key: string, path?: Path)`
- `Josh#has(keyPath: KeyPath)` --> `(key: string, path?: Path)`
- `Josh#inc(keyPath: KeyPath)` --> `(key: string, path?: Path`
- `Josh#math(keyPath: KeyPath, operator: MathOperator, operand: number)` --> `(key: string, operator: MathOperator, operand: number, path?: Path)`
- `Josh#push(keyPath: KeyPath, value: Value)` --> `(key: string, value: Value, path?: Path)`
- `Josh#remove(keyPath: KeyPath, valueOrHook: Primitive | Payload.Hook<Value>)` --> `(key: string, valueOrHook: Primitive | Payload.Hook<Value>, path?: Path)`
- `Josh#set(keyPath: KeyPath, value: Value)` --> `(key: string, value: Value, path?: Path)`
- `Josh#resolvePath()` now resolves index paths.