### PR TITLE
feat: add provider migrations

### DIFF
--- a/src/lib/structures/JoshProvider.ts
+++ b/src/lib/structures/JoshProvider.ts
@@ -37,6 +37,8 @@ export abstract class JoshProvider<StoredValue = unknown> {
    */
   public options: JoshProvider.Options;
 
+  public abstract version: string;
+
   public constructor(options: JoshProvider.Options = {}) {
     this.options = options;
   }

--- a/src/lib/structures/JoshProvider.ts
+++ b/src/lib/structures/JoshProvider.ts
@@ -480,7 +480,7 @@ export abstract class JoshProvider<StoredValue = unknown> {
     return version
       .split('.')
       .map(Number)
-      .reduce((semver, value, index) => ({ ...semver, [index === 0 ? 'major' : index === 1 ? 'minor' : 'patch']: value }), {
+      .reduce((semver, value, index) => ({ ...semver, [['major', 'minor', 'patch'][index]]: value }), {
         fullVersion: version,
         major: 0,
         minor: 0,

--- a/src/lib/structures/JoshProvider.ts
+++ b/src/lib/structures/JoshProvider.ts
@@ -88,8 +88,6 @@ export abstract class JoshProvider<StoredValue = unknown> {
     return Promise.resolve(context);
   }
 
-  public abstract needsMigration(): Awaitable<boolean>;
-
   /**
    * A method which generates a unique automatic key. This key must be unique and cannot overlap other keys.
    * @since 2.0.0
@@ -487,6 +485,8 @@ export abstract class JoshProvider<StoredValue = unknown> {
         patch: 0
       });
   }
+
+  protected abstract needsMigration(): Awaitable<boolean>;
 }
 
 export namespace JoshProvider {

--- a/src/lib/structures/JoshProvider.ts
+++ b/src/lib/structures/JoshProvider.ts
@@ -439,6 +439,23 @@ export abstract class JoshProvider<StoredValue = unknown> {
 
     throw new Error(`Unknown identifier: ${identifier}`);
   }
+
+  /**
+   * Resolves a version.
+   * @param version The version to resolve.
+   * @returns The resolved version.
+   */
+  protected resolveVersion(version: string): JoshProvider.SemverVersion {
+    return version
+      .split('.')
+      .map(Number)
+      .reduce((semver, value, index) => ({ ...semver, [index === 0 ? 'major' : index === 1 ? 'minor' : 'patch']: value }), {
+        fullVersion: version,
+        major: 0,
+        minor: 0,
+        patch: 0
+      });
+  }
 }
 
 export namespace JoshProvider {
@@ -491,6 +508,16 @@ export namespace JoshProvider {
      * @since 2.0.0
      */
     error?: JoshProviderError;
+  }
+
+  export interface SemverVersion {
+    fullVersion: string;
+
+    major: number;
+
+    minor: number;
+
+    patch: number;
   }
 
   export interface Constructor {

--- a/src/lib/structures/JoshProvider.ts
+++ b/src/lib/structures/JoshProvider.ts
@@ -455,7 +455,13 @@ export namespace JoshProvider {
    * }
    * ```
    */
-  export interface Options {}
+  export interface Options {
+    /**
+     * Whether to allow automatic provider data migrations.
+     * @since 2.0.0
+     */
+    allowMigrations?: boolean;
+  }
 
   /**
    * The context sent by the {@link Josh} instance.

--- a/src/lib/structures/default-provider/MapProvider.ts
+++ b/src/lib/structures/default-provider/MapProvider.ts
@@ -25,6 +25,8 @@ import { JoshProvider } from '../JoshProvider';
  * @since 2.0.0
  */
 export class MapProvider<StoredValue = unknown> extends JoshProvider<StoredValue> {
+  public version = '[VI]{version}[/VI]';
+
   /**
    * The [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) cache to store data.
    * @since 2.0.0

--- a/src/lib/structures/default-provider/MapProvider.ts
+++ b/src/lib/structures/default-provider/MapProvider.ts
@@ -594,6 +594,10 @@ export class MapProvider<StoredValue = unknown> extends JoshProvider<StoredValue
     return payload;
   }
 
+  protected needsMigration(): boolean {
+    return false;
+  }
+
   private randomEntriesWithoutDuplicates(data: [string, StoredValue][]): [string, StoredValue] {
     const entries = Array.from(this.cache.entries());
     const entry = entries[Math.floor(Math.random() * entries.length)];


### PR DESCRIPTION
This PR implements provider migrations to allow for smooth transitions between major versions.

# Changes

- Add `JoshProvider.Options#allowMigrations` optional property
- Add `JoshProvider#resolveVersion()` protected method
- Add `JoshProvider#version` abstract method
- Add `JoshProvider#migrations` property
- Add functionality for migrations in the `JoshProvider#init()` method