### PR TITLE
refactor: formatting

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,13 +3,13 @@
   "rules": {
     "@typescript-eslint/no-namespace": "off",
     "@typescript-eslint/class-literal-property-style": "off",
+    "curly": ["error", "multi-line"],
     "no-lone-blocks": "error",
     "no-tabs": "error",
     "padding-line-between-statements": [
       "error",
       { "blankLine": "never", "prev": ["const", "let", "var"], "next": ["const", "let", "var"] },
       { "blankLine": "never", "prev": "case", "next": "case" },
-      { "blankLine": "never", "prev": "expression", "next": "expression" },
       { "blankLine": "never", "prev": "for", "next": "for" },
       { "blankLine": "never", "prev": "if", "next": "if" },
       {

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,15 +1,6 @@
 {
   "$schema": "http://json.schemastore.org/prettierrc",
   "endOfLine": "lf",
-  "overrides": [
-    {
-      "files": "*.yml",
-      "options": {
-        "tabWidth": 2,
-        "useTabs": false
-      }
-    }
-  ],
   "printWidth": 150,
   "quoteProps": "as-needed",
   "semi": true,

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -4,8 +4,8 @@ nodeLinker: node-modules
 
 plugins:
   - path: .yarn/plugins/@yarnpkg/plugin-typescript.cjs
-    spec: "@yarnpkg/plugin-typescript"
+    spec: '@yarnpkg/plugin-typescript'
   - path: .yarn/plugins/@yarnpkg/plugin-interactive-tools.cjs
-    spec: "@yarnpkg/plugin-interactive-tools"
+    spec: '@yarnpkg/plugin-interactive-tools'
 
 yarnPath: .yarn/releases/yarn-3.2.1.cjs

--- a/src/lib/structures/Josh.ts
+++ b/src/lib/structures/Josh.ts
@@ -86,13 +86,15 @@ export class Josh<StoredValue = unknown> {
     this.middlewares = new MiddlewareStore({ instance: this });
 
     if (autoEnsure !== undefined) this.use(new AutoEnsure<StoredValue>(autoEnsure));
-    if (middlewares !== undefined && Array.isArray(middlewares))
+    if (middlewares !== undefined && Array.isArray(middlewares)) {
       for (const middleware of middlewares.filter((middleware) => {
         if (!(middleware instanceof Middleware)) emitWarning(this.error(Josh.Identifiers.InvalidMiddleware));
 
         return middleware instanceof Middleware;
-      }) as Middleware<NonNullObject, StoredValue>[])
+      }) as Middleware<NonNullObject, StoredValue>[]) {
         this.use(middleware);
+      }
+    }
   }
 
   /**

--- a/src/lib/structures/Middleware.ts
+++ b/src/lib/structures/Middleware.ts
@@ -238,11 +238,12 @@ export class Middleware<ContextData extends NonNullObject, StoredValue = unknown
    * @since 2.0.0
    */
   protected get instance(): Josh<StoredValue> {
-    if (this.store === undefined)
+    if (this.store === undefined) {
       throw new JoshError({
         identifier: Middleware.Identifiers.StoreNotFound,
         message: 'The "store" property is undefined. This usually means this middleware has not been initiated.'
       });
+    }
 
     return this.store.instance;
   }

--- a/src/lib/structures/default-provider/MapProvider.ts
+++ b/src/lib/structures/default-provider/MapProvider.ts
@@ -60,13 +60,15 @@ export class MapProvider<StoredValue = unknown> extends JoshProvider<StoredValue
     const { key, path } = payload;
     const getPayload = this[Method.Get]({ method: Method.Get, key, path });
 
-    if (!isPayloadWithData(getPayload))
+    if (!isPayloadWithData(getPayload)) {
       return { ...payload, error: this.error({ identifier: CommonIdentifiers.MissingData, method: Method.Dec }, { key, path }) };
+    }
 
     const { data } = getPayload;
 
-    if (typeof data !== 'number')
+    if (typeof data !== 'number') {
       return { ...payload, error: this.error({ identifier: CommonIdentifiers.InvalidDataType, method: Method.Dec }, { key, path, type: 'number' }) };
+    }
 
     this[Method.Set]({ method: Method.Set, key, path, value: data - 1 });
 
@@ -139,13 +141,17 @@ export class MapProvider<StoredValue = unknown> extends JoshProvider<StoredValue
       for (const [key, storedValue] of this.cache.entries()) {
         const data = getProperty(storedValue, path, false);
 
-        if (data === PROPERTY_NOT_FOUND)
+        if (data === PROPERTY_NOT_FOUND) {
           return { ...payload, error: this.error({ identifier: CommonIdentifiers.MissingData, method: Method.Every }, { key, path }) };
-        if (!isPrimitive(data))
+        }
+
+        if (!isPrimitive(data)) {
           return {
             ...payload,
             error: this.error({ identifier: CommonIdentifiers.InvalidDataType, method: Method.Every }, { key, path, type: 'primitive' })
           };
+        }
+
         if (data === value) continue;
 
         payload.data = false;
@@ -172,13 +178,17 @@ export class MapProvider<StoredValue = unknown> extends JoshProvider<StoredValue
       for (const [key, storedValue] of this.cache.entries()) {
         const data = getProperty(storedValue, path, false);
 
-        if (data === PROPERTY_NOT_FOUND)
+        if (data === PROPERTY_NOT_FOUND) {
           return { ...payload, error: this.error({ identifier: CommonIdentifiers.MissingData, method: Method.Filter }, { key, path }) };
-        if (!isPrimitive(data))
+        }
+
+        if (!isPrimitive(data)) {
           return {
             ...payload,
             error: this.error({ identifier: CommonIdentifiers.InvalidDataType, method: Method.Filter }, { key, path, type: 'primitive' })
           };
+        }
+
         if (data === value) payload.data[key] = storedValue;
       }
     }
@@ -219,13 +229,17 @@ export class MapProvider<StoredValue = unknown> extends JoshProvider<StoredValue
 
         const data = getProperty(storedValue, path, false);
 
-        if (data === PROPERTY_NOT_FOUND)
+        if (data === PROPERTY_NOT_FOUND) {
           return { ...payload, error: this.error({ identifier: CommonIdentifiers.MissingData, method: Method.Find }, { key, path }) };
-        if (!isPrimitive(data))
+        }
+
+        if (!isPrimitive(data)) {
           return {
             ...payload,
             error: this.error({ identifier: CommonIdentifiers.InvalidDataType, method: Method.Find }, { key, path, type: 'primitive' })
           };
+        }
+
         if (data !== value) continue;
 
         payload.data = [key, storedValue];
@@ -271,13 +285,15 @@ export class MapProvider<StoredValue = unknown> extends JoshProvider<StoredValue
     const { key, path } = payload;
     const getPayload = this[Method.Get]({ method: Method.Get, key, path });
 
-    if (!isPayloadWithData(getPayload))
+    if (!isPayloadWithData(getPayload)) {
       return { ...payload, error: this.error({ identifier: CommonIdentifiers.MissingData, method: Method.Inc }, { key, path }) };
+    }
 
     const { data } = getPayload;
 
-    if (typeof data !== 'number')
+    if (typeof data !== 'number') {
       return { ...payload, error: this.error({ identifier: CommonIdentifiers.InvalidDataType, method: Method.Inc }, { key, path, type: 'number' }) };
+    }
 
     this[Method.Set]({ method: Method.Set, key, path, value: data + 1 });
 
@@ -318,13 +334,15 @@ export class MapProvider<StoredValue = unknown> extends JoshProvider<StoredValue
     const { key, path, operator, operand } = payload;
     const getPayload = this[Method.Get]<number>({ method: Method.Get, key, path });
 
-    if (!isPayloadWithData(getPayload))
+    if (!isPayloadWithData(getPayload)) {
       return { ...payload, error: this.error({ identifier: CommonIdentifiers.MissingData, method: Method.Math }, { key, path }) };
+    }
 
     let { data } = getPayload;
 
-    if (typeof data !== 'number')
+    if (typeof data !== 'number') {
       return { ...payload, error: this.error({ identifier: CommonIdentifiers.InvalidDataType, method: Method.Math }, { key, path, type: 'number' }) };
+    }
 
     switch (operator) {
       case MathOperator.Addition:
@@ -385,13 +403,17 @@ export class MapProvider<StoredValue = unknown> extends JoshProvider<StoredValue
       for (const [key, storedValue] of this.cache.entries()) {
         const data = getProperty<StoredValue>(storedValue, path);
 
-        if (data === PROPERTY_NOT_FOUND)
+        if (data === PROPERTY_NOT_FOUND) {
           return { ...payload, error: this.error({ identifier: CommonIdentifiers.MissingData, method: Method.Partition }, { key, path }) };
-        if (!isPrimitive(data))
+        }
+
+        if (!isPrimitive(data)) {
           return {
             ...payload,
             error: this.error({ identifier: CommonIdentifiers.InvalidDataType, method: Method.Partition }, { key, path, type: 'primitive' })
           };
+        }
+
         if (value === data) payload.data.truthy[key] = storedValue;
         else payload.data.falsy[key] = storedValue;
       }
@@ -404,13 +426,15 @@ export class MapProvider<StoredValue = unknown> extends JoshProvider<StoredValue
     const { key, path, value } = payload;
     const getPayload = this[Method.Get]({ method: Method.Get, key, path });
 
-    if (!isPayloadWithData(getPayload))
+    if (!isPayloadWithData(getPayload)) {
       return { ...payload, error: this.error({ identifier: CommonIdentifiers.MissingData, method: Method.Push }, { key, path }) };
+    }
 
     const { data } = getPayload;
 
-    if (!Array.isArray(data))
+    if (!Array.isArray(data)) {
       return { ...payload, error: this.error({ identifier: CommonIdentifiers.InvalidDataType, method: Method.Push }, { key, path, type: 'array' }) };
+    }
 
     data.push(value);
     this[Method.Set]({ method: Method.Set, key, path, value: data });
@@ -423,17 +447,19 @@ export class MapProvider<StoredValue = unknown> extends JoshProvider<StoredValue
 
     const { count, duplicates } = payload;
 
-    if (this.cache.size < count)
+    if (this.cache.size < count) {
       return {
         ...payload,
         error: this.error({ identifier: CommonIdentifiers.InvalidCount, method: Method.Random })
       };
+    }
 
     const data: [string, StoredValue][] = [];
     const entries = Array.from(this.cache.entries());
 
-    for (let i = 0; i < count; i++)
+    for (let i = 0; i < count; i++) {
       data.push(duplicates ? entries[Math.floor(Math.random() & entries.length)] : this.randomEntriesWithoutDuplicates(data));
+    }
 
     payload.data = data.map(([, value]) => value);
 
@@ -445,18 +471,20 @@ export class MapProvider<StoredValue = unknown> extends JoshProvider<StoredValue
 
     const { count, duplicates } = payload;
 
-    if (this.cache.size < count)
+    if (this.cache.size < count) {
       return {
         ...payload,
         error: this.error({ identifier: CommonIdentifiers.InvalidCount, method: Method.RandomKey })
       };
+    }
 
     payload.data = [];
 
     const keys = Array.from(this.cache.keys());
 
-    for (let i = 0; i < count; i++)
+    for (let i = 0; i < count; i++) {
       payload.data.push(duplicates ? keys[Math.floor(Math.random() * keys.length)] : this.randomKeyWithoutDuplicates(payload.data));
+    }
 
     return payload;
   }
@@ -468,16 +496,18 @@ export class MapProvider<StoredValue = unknown> extends JoshProvider<StoredValue
       const { key, path, hook } = payload;
       const getPayload = this[Method.Get]<Value[]>({ method: Method.Get, key, path });
 
-      if (!isPayloadWithData(getPayload))
+      if (!isPayloadWithData(getPayload)) {
         return { ...payload, error: this.error({ identifier: CommonIdentifiers.MissingData, method: Method.Remove }, { key, path }) };
+      }
 
       const { data } = getPayload;
 
-      if (!Array.isArray(data))
+      if (!Array.isArray(data)) {
         return {
           ...payload,
           error: this.error({ identifier: CommonIdentifiers.InvalidDataType, method: Method.Remove }, { key, path, type: 'array' })
         };
+      }
 
       const filterValues = await Promise.all(data.map(hook));
 
@@ -488,16 +518,18 @@ export class MapProvider<StoredValue = unknown> extends JoshProvider<StoredValue
       const { key, path, value } = payload;
       const getPayload = this[Method.Get]({ method: Method.Get, key, path });
 
-      if (!isPayloadWithData(getPayload))
+      if (!isPayloadWithData(getPayload)) {
         return { ...payload, error: this.error({ identifier: CommonIdentifiers.MissingData, method: Method.Remove }, { key, path }) };
+      }
 
       const { data } = getPayload;
 
-      if (!Array.isArray(data))
+      if (!Array.isArray(data)) {
         return {
           ...payload,
           error: this.error({ identifier: CommonIdentifiers.InvalidDataType, method: Method.Remove }, { key, path, type: 'array' })
         };
+      }
 
       this[Method.Set]({ method: Method.Set, key, path, value: data.filter((storedValue) => value !== storedValue) });
     }
@@ -521,9 +553,10 @@ export class MapProvider<StoredValue = unknown> extends JoshProvider<StoredValue
   public [Method.SetMany](payload: Payloads.SetMany): Payloads.SetMany {
     const { entries, overwrite } = payload;
 
-    for (const [{ key, path }, value] of entries)
+    for (const [{ key, path }, value] of entries) {
       if (overwrite) this[Method.Set]({ method: Method.Set, key, path, value });
       else if (!this[Method.Has]({ method: Method.Has, key, path }).data) this[Method.Set]({ method: Method.Set, key, path, value });
+    }
 
     return payload;
   }
@@ -559,13 +592,17 @@ export class MapProvider<StoredValue = unknown> extends JoshProvider<StoredValue
       for (const [key, storedValue] of this.cache.entries()) {
         const data = getProperty(storedValue, path, false);
 
-        if (data === PROPERTY_NOT_FOUND)
+        if (data === PROPERTY_NOT_FOUND) {
           return { ...payload, error: this.error({ identifier: CommonIdentifiers.MissingData, method: Method.Some }, { key, path }) };
-        if (!isPrimitive(data))
+        }
+
+        if (!isPrimitive(data)) {
           return {
             ...payload,
             error: this.error({ identifier: CommonIdentifiers.InvalidDataType, method: Method.Some }, { key, path, type: 'primitive' })
           };
+        }
+
         if (data !== value) continue;
 
         payload.data = true;
@@ -581,8 +618,9 @@ export class MapProvider<StoredValue = unknown> extends JoshProvider<StoredValue
     const { key, hook } = payload;
     const getPayload = this[Method.Get]({ method: Method.Get, key, path: [] });
 
-    if (!isPayloadWithData<StoredValue>(getPayload))
+    if (!isPayloadWithData<StoredValue>(getPayload)) {
       return { ...payload, error: this.error({ identifier: CommonIdentifiers.MissingData, method: Method.Update }, { key }) };
+    }
 
     const { data } = getPayload;
 
@@ -606,8 +644,9 @@ export class MapProvider<StoredValue = unknown> extends JoshProvider<StoredValue
     const entry = entries[Math.floor(Math.random() * entries.length)];
 
     if (data.length === 0) return entry;
-    if (isPrimitive(entry[1]) && data.some(([key, value]) => entry[0] === key && entry[1] === value))
+    if (isPrimitive(entry[1]) && data.some(([key, value]) => entry[0] === key && entry[1] === value)) {
       return this.randomEntriesWithoutDuplicates(data);
+    }
 
     return entry;
   }


### PR DESCRIPTION
# Changes

- Add `curly` rule to `.eslintrc`. This will force curly brakcets to be added if the statement is nested.
- Remove `overrides` property in `.prettierrc` as it had no effect.